### PR TITLE
Support alignment similarity, expose more clustering options

### DIFF
--- a/.changeset/nine-moons-share.md
+++ b/.changeset/nine-moons-share.md
@@ -1,0 +1,7 @@
+---
+'@platforma-open/milaboratories.clonotype-clustering.workflow': minor
+'@platforma-open/milaboratories.clonotype-clustering.model': minor
+'@platforma-open/milaboratories.clonotype-clustering.ui': minor
+---
+
+Expose clustering options

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -13,6 +13,7 @@ export type BlockArgs = {
   sequenceType: 'aminoacid' | 'nucleotide';
   identity: number;
   similarityType: 'alignment-score' | 'sequence-identity';
+  coverageThreshold: number;  // fraction of aligned residues required
 };
 
 export type UiState = {
@@ -28,6 +29,7 @@ export const model = BlockModel.create()
     sequenceType: 'aminoacid',
     sequencesRef: [],
     similarityType: 'sequence-identity',
+    coverageThreshold: 0.8,  // default value matching MMseqs2 default
   })
 
   .withUiState<UiState>({

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -14,6 +14,7 @@ export type BlockArgs = {
   identity: number;
   similarityType: 'alignment-score' | 'sequence-identity';
   coverageThreshold: number;  // fraction of aligned residues required
+  coverageMode: 0 | 1 | 2 | 3 | 4 | 5; // MMseqs2 coverage modes
 };
 
 export type UiState = {
@@ -29,7 +30,8 @@ export const model = BlockModel.create()
     sequenceType: 'aminoacid',
     sequencesRef: [],
     similarityType: 'sequence-identity',
-    coverageThreshold: 0.8,  // default value matching MMseqs2 default
+    coverageThreshold: 0.8, // default value matching MMseqs2 default
+    coverageMode: 1, // default to coverage of target
   })
 
   .withUiState<UiState>({

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -12,6 +12,7 @@ export type BlockArgs = {
   // Added sequenceType here for future use in algorithm selection in workflow
   sequenceType: 'aminoacid' | 'nucleotide';
   identity: number;
+  similarityType: 'alignment-score' | 'sequence-identity';
 };
 
 export type UiState = {
@@ -26,6 +27,7 @@ export const model = BlockModel.create()
     identity: 0.8,
     sequenceType: 'aminoacid',
     sequencesRef: [],
+    similarityType: 'sequence-identity',
   })
 
   .withUiState<UiState>({

--- a/ui/src/pages/BubblePlotPage.vue
+++ b/ui/src/pages/BubblePlotPage.vue
@@ -23,13 +23,15 @@ const defaultOptions = computed((): GraphMakerProps['defaultOptions'] => {
     },
     {
       inputName: 'valueSize',
-      // selectedSource: app.model.outputs.clusterAbundanceSpec, // @TODO: figure out why this is not working (Elena)
-      selectedSource: {
-        kind: 'PColumn',
-        name: app.model.outputs.clusterAbundanceSpec.name,
-        valueType: app.model.outputs.clusterAbundanceSpec.valueType,
-        axesSpec: [],
-      },
+      selectedSource: app.model.outputs.clusterAbundanceSpec, // @TODO: figure out why this is not working (Elena)
+      // If switch to search mode use more queries to get only "pl7.app/label": "Number of UMIs in cluster" and not
+      // "pl7.app/label": "Number of UMIs",
+      // selectedSource: {
+      //   kind: 'PColumn',
+      //   name: app.model.outputs.clusterAbundanceSpec.name,
+      //   valueType: app.model.outputs.clusterAbundanceSpec.valueType,
+      //   axesSpec: [],
+      // },
     },
     {
       inputName: 'y',
@@ -65,7 +67,7 @@ const defaultOptions = computed((): GraphMakerProps['defaultOptions'] => {
     <GraphMaker
       v-model="app.model.ui.graphStateBubble"
       chartType="bubble"
-      :data-state-key="app.model.args.datasetRef"
+      :data-state-key="app.model.outputs.clustersPf"
       :p-frame="app.model.outputs.clustersPf"
       :default-options="defaultOptions"
     />

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -123,6 +123,18 @@ if (!app.model.args.similarityType) {
         </template>
       </PlNumberField>
 
+      <PlNumberField
+        v-model="app.model.args.coverageThreshold"
+        label="Coverage Threshold"
+        :minValue="0.1"
+        :step="0.1"
+        :maxValue="1.0"
+      >
+        <template #tooltip>
+          Select min fraction of aligned (covered) residues of clonotypes in the cluster.
+        </template>
+      </PlNumberField>
+
       <PlAccordionSection label="Advanced Settings">
         <PlDropdown
           v-model="app.model.args.similarityType"
@@ -130,7 +142,7 @@ if (!app.model.args.similarityType) {
           label="Similarity Type"
         >
           <template #tooltip>
-            Choose how sequence similarity is calculated during clustering
+            Type of similarity score used for clustering.
           </template>
         </PlDropdown>
       </PlAccordionSection>

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -62,9 +62,22 @@ const similarityTypeOptions = [
   { label: 'Sequence Identity', value: 'sequence-identity' },
 ];
 
+const coverageModeOptions = [
+  { label: 'Coverage of query and target', value: 0 },
+  { label: 'Coverage of target', value: 1 },
+  { label: 'Coverage of query', value: 2 },
+  { label: 'Target length ≥ x% of query length', value: 3 },
+  { label: 'Query length ≥ x% of target length', value: 4 },
+  { label: 'Shorter sequence ≥ x% of longer', value: 5 },
+];
+
 // Initialize default values if not set
 if (!app.model.args.similarityType) {
   app.model.args.similarityType = 'sequence-identity';
+}
+
+if (app.model.args.coverageMode === undefined) {
+  app.model.args.coverageMode = 1;
 }
 
 </script>
@@ -143,6 +156,16 @@ if (!app.model.args.similarityType) {
         >
           <template #tooltip>
             Type of similarity score used for clustering.
+          </template>
+        </PlDropdown>
+
+        <PlDropdown
+          v-model="app.model.args.coverageMode"
+          :options="coverageModeOptions"
+          label="Coverage Mode"
+        >
+          <template #tooltip>
+            How to calculate the coverage between sequences for the coverage threshold.
           </template>
         </PlDropdown>
       </PlAccordionSection>

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -5,11 +5,13 @@ import type {
 } from '@platforma-sdk/ui-vue';
 import {
   listToOptions,
+  PlAccordionSection,
   PlAgDataTableToolsPanel,
   PlAgDataTableV2,
   PlBlockPage,
   PlBtnGhost,
   PlBtnGroup,
+  PlDropdown,
   PlDropdownMulti,
   PlDropdownRef,
   PlMaskIcon24,
@@ -54,6 +56,16 @@ const tableLoadingText = computed(() => {
 });
 
 const sequenceType = listToOptions(['aminoacid', 'nucleotide']);
+
+const similarityTypeOptions = [
+  { label: 'Alignment Score', value: 'alignment-score' },
+  { label: 'Sequence Identity', value: 'sequence-identity' },
+];
+
+// Initialize default values if not set
+if (!app.model.args.similarityType) {
+  app.model.args.similarityType = 'sequence-identity';
+}
 
 </script>
 
@@ -110,6 +122,18 @@ const sequenceType = listToOptions(['aminoacid', 'nucleotide']);
           Select min identity of clonotypes in the cluster.
         </template>
       </PlNumberField>
+
+      <PlAccordionSection label="Advanced Settings">
+        <PlDropdown
+          v-model="app.model.args.similarityType"
+          :options="similarityTypeOptions"
+          label="Similarity Type"
+        >
+          <template #tooltip>
+            Choose how sequence similarity is calculated during clustering
+          </template>
+        </PlDropdown>
+      </PlAccordionSection>
     </PlSlideModal>
   </PlBlockPage>
 </template>

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -123,6 +123,8 @@ wf.body(func(args) {
 		arg("--min-seq-id").arg(string(args.identity)).
 		arg("-c").arg(string(args.identity)).
 		arg("--cov-mode").arg("1").
+		//  --similarity-type INT            Type of score used for clustering. 1: alignment score 2: sequence identity [2]
+		arg("--similarity-type").arg(args.similarityType == "sequence-identity" ? "2" : "1").
 		addFile("input.fasta", fasta.getFile("output.fasta")).
 		saveFile("result_cluster.tsv").
 		run()

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -122,7 +122,7 @@ wf.body(func(args) {
 		arg("tmp").
 		arg("--min-seq-id").arg(string(args.identity)).
 		arg("-c").arg(string(args.coverageThreshold)).
-		arg("--cov-mode").arg("1").
+		arg("--cov-mode").arg(string(args.coverageMode)).
 		//  --similarity-type INT            Type of score used for clustering. 1: alignment score 2: sequence identity [2]
 		arg("--similarity-type").arg(args.similarityType == "sequence-identity" ? "2" : "1").
 		addFile("input.fasta", fasta.getFile("output.fasta")).

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -121,7 +121,7 @@ wf.body(func(args) {
 		arg("result").
 		arg("tmp").
 		arg("--min-seq-id").arg(string(args.identity)).
-		arg("-c").arg(string(args.identity)).
+		arg("-c").arg(string(args.coverageThreshold)).
 		arg("--cov-mode").arg("1").
 		//  --similarity-type INT            Type of score used for clustering. 1: alignment score 2: sequence identity [2]
 		arg("--similarity-type").arg(args.similarityType == "sequence-identity" ? "2" : "1").


### PR DESCRIPTION
Exposed key clustering options:

- `-c` Coverage Threshold. Minimum % of aligned residues that sequences need to have with reference sequence to join a cluster (set default to 0.8; previously hardcoded to the same as identity)

In advanced settings:
- `--cov-mode` How the coverage is calculated  (kept previous default: 1; coverage of target)
- `--similarity-type` To select what type of score, sequence identity or aligment score is used as similarity metric for making clusters  (kept the previous and mmseq default: sequence identity)

> In the context of cluster or linclust, the query is seen representative sequence and target is a member sequence

https://github.com/soedinglab/mmseqs2/wiki#how-to-set-the-right-alignment-coverage-to-cluster

