### PR TITLE
MILAB-2545 add cluster size hist

### DIFF
--- a/.changeset/busy-parents-like.md
+++ b/.changeset/busy-parents-like.md
@@ -1,0 +1,6 @@
+---
+'@platforma-open/milaboratories.clonotype-clustering.model': minor
+'@platforma-open/milaboratories.clonotype-clustering.ui': minor
+---
+
+Add cluster size histogram, remove advanced settings panel and fix plot defaults picking up data from previous block if there is another clonotype-clustering block.

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -21,7 +21,7 @@ export type BlockArgs = {
   identity: number;
   similarityType: 'alignment-score' | 'sequence-identity';
   coverageThreshold: number; // fraction of aligned residues required
-  coverageMode: 0 | 1 | 2 | 3 | 4 | 5; // MMseqs2 coverage modes
+  coverageMode: 0 | 1 | 2 | 3 | 4 | 5; // Complex option. Not available to user
 };
 
 export type UiState = {
@@ -40,7 +40,7 @@ export const model = BlockModel.create()
     sequencesRef: [],
     similarityType: 'sequence-identity',
     coverageThreshold: 0.8, // default value matching MMseqs2 default
-    coverageMode: 1, // default to coverage of target
+    coverageMode: 0, // default to coverage of query and target
   })
 
   .withUiState<UiState>({

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -1,6 +1,7 @@
 import type { GraphMakerState } from '@milaboratories/graph-maker';
 import type {
   InferOutputsType,
+  PColumnIdAndSpec,
   PColumnSpec,
   PFrameHandle,
   PlDataTableState,
@@ -212,6 +213,22 @@ export const model = BlockModel.create()
     }
 
     return createPFrameForGraphs(ctx, pCols);
+  })
+
+  // Returns a list of Pcols for plot defaults
+  .output('clustersPfPcols', (ctx) => {
+    const pCols = ctx.outputs?.resolve('pf')?.getPColumns();
+    if (pCols === undefined) {
+      return undefined;
+    }
+
+    return pCols.map(
+      (c) =>
+        ({
+          columnId: c.id,
+          spec: c.spec,
+        } satisfies PColumnIdAndSpec),
+    );
   })
 
   .output('isRunning', (ctx) => ctx.outputs?.getIsReadyOrError() === false)

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -29,6 +29,7 @@ export type UiState = {
   tableState: PlDataTableState;
   graphStateBubble: GraphMakerState;
   alignmentModel: PlMultiSequenceAlignmentModel;
+  graphStateHistogram: GraphMakerState;
 };
 
 export const model = BlockModel.create()
@@ -58,6 +59,21 @@ export const model = BlockModel.create()
       },
     },
     alignmentModel: {},
+    graphStateHistogram: {
+      title: 'Histogram',
+      template: 'bins',
+      currentTab: null,
+      layersSettings: {
+        bins: { fillColor: '#99e099' },
+      },
+      axesSettings: {
+        axisY: {
+          axisLabelsAngle: 90,
+          scale: 'log',
+        },
+        other: { binsCount: 30 },
+      },
+    },
   })
 
   .argsValid((ctx) => ctx.args.datasetRef !== undefined
@@ -205,6 +221,7 @@ export const model = BlockModel.create()
   .sections((_ctx) => [
     { type: 'link', href: '/', label: 'Main' },
     { type: 'link', href: '/bubble', label: 'Clusters Plot' },
+    { type: 'link', href: '/histogram', label: 'Cluster Size Histogram' },
   ])
 
   .done();

--- a/ui/src/app.ts
+++ b/ui/src/app.ts
@@ -2,6 +2,7 @@ import { model } from '@platforma-open/milaboratories.clonotype-clustering.model
 import { defineApp } from '@platforma-sdk/ui-vue';
 import BubblePlotPage from './pages/BubblePlotPage.vue';
 import MainPage from './pages/MainPage.vue';
+import HistogramPage from './pages/HistogramPage.vue';
 export const sdkPlugin = defineApp(model, (app) => {
   return {
     progress: () => {
@@ -10,6 +11,7 @@ export const sdkPlugin = defineApp(model, (app) => {
     routes: {
       '/': () => MainPage,
       '/bubble': () => BubblePlotPage,
+      '/histogram': () => HistogramPage,
     },
   };
 });

--- a/ui/src/pages/BubblePlotPage.vue
+++ b/ui/src/pages/BubblePlotPage.vue
@@ -3,61 +3,52 @@ import '@milaboratories/graph-maker/styles';
 import { PlBlockPage } from '@platforma-sdk/ui-vue';
 import { useApp } from '../app';
 
-import type { GraphMakerProps } from '@milaboratories/graph-maker';
+import type { GraphMakerProps, PredefinedGraphOption } from '@milaboratories/graph-maker';
 import { GraphMaker } from '@milaboratories/graph-maker';
 import { computed } from 'vue';
+import type { PColumnIdAndSpec } from '@platforma-sdk/model';
 
 const app = useApp();
 
+// if there is no output or abundance spec, return undefined
 const defaultOptions = computed((): GraphMakerProps['defaultOptions'] => {
-  if (app.model.outputs.clusterAbundanceSpec === undefined) return undefined;
-  return [
+  if (!app.model.outputs.clustersPfPcols || !app.model.outputs.clusterAbundanceSpec)
+    return undefined;
+
+  const bubblePcols = app.model.outputs.clustersPfPcols;
+  function getIndex(name: string, pcols: PColumnIdAndSpec[]): number {
+    return pcols.findIndex((p) => (p.spec.name === name
+    ));
+  }
+  const defaults: PredefinedGraphOption<'bubble'>[] = [
     {
-      inputName: 'valueColor',
-      selectedSource: {
-        kind: 'PColumn',
-        name: 'pl7.app/vdj/clustering/clusterSize',
-        valueType: 'Int',
-        axesSpec: [],
-      },
-    },
-    {
-      inputName: 'valueSize',
-      selectedSource: app.model.outputs.clusterAbundanceSpec, // @TODO: figure out why this is not working (Elena)
-      // If switch to search mode use more queries to get only "pl7.app/label": "Number of UMIs in cluster" and not
-      // "pl7.app/label": "Number of UMIs",
-      // selectedSource: {
-      //   kind: 'PColumn',
-      //   name: app.model.outputs.clusterAbundanceSpec.name,
-      //   valueType: app.model.outputs.clusterAbundanceSpec.valueType,
-      //   axesSpec: [],
-      // },
+      inputName: 'x',
+      selectedSource: bubblePcols[getIndex(app.model.outputs.clusterAbundanceSpec.name,
+        bubblePcols)].spec.axesSpec[1],
     },
     {
       inputName: 'y',
-      selectedSource: {
-        name: 'pl7.app/sampleId',
-        type: 'String',
-      },
+      selectedSource: bubblePcols[getIndex(app.model.outputs.clusterAbundanceSpec.name,
+        bubblePcols)].spec.axesSpec[0],
     },
     {
-      inputName: 'x',
-      selectedSource: {
-        name: 'pl7.app/vdj/clusterId',
-        type: 'String',
-      },
+      inputName: 'valueColor',
+      selectedSource: bubblePcols[getIndex('pl7.app/vdj/clustering/clusterSize',
+        bubblePcols)].spec,
+    },
+    {
+      inputName: 'valueSize',
+      selectedSource: bubblePcols[getIndex(app.model.outputs.clusterAbundanceSpec.name,
+        bubblePcols)].spec,
     },
     {
       inputName: 'filters',
-      selectedSource: {
-        kind: 'PColumn',
-        name: 'pl7.app/vdj/clustering/clusterSize',
-        valueType: 'Int',
-        axesSpec: [],
-      },
+      selectedSource: bubblePcols[getIndex('pl7.app/vdj/clustering/clusterSize',
+        bubblePcols)].spec,
       selectedFilterRange: { min: 3 },
     },
   ];
+  return defaults;
 });
 
 </script>

--- a/ui/src/pages/HistogramPage.vue
+++ b/ui/src/pages/HistogramPage.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+import type { PredefinedGraphOption } from '@milaboratories/graph-maker';
+import { GraphMaker } from '@milaboratories/graph-maker';
+import { PlBlockPage } from '@platforma-sdk/ui-vue';
+import { useApp } from '../app';
+
+const app = useApp();
+
+const defaultOptions: PredefinedGraphOption<'histogram'>[] = [
+  {
+    inputName: 'value',
+    selectedSource: {
+      kind: 'PColumn',
+      name: 'pl7.app/vdj/clustering/clusterSize',
+      valueType: 'Int',
+      axesSpec: [],
+    },
+  },
+];
+
+</script>
+
+<template>
+  <PlBlockPage>
+    <GraphMaker
+      v-model="app.model.ui.graphStateHistogram"
+      chartType="histogram"
+      :p-frame="app.model.outputs.clustersPf"
+      :default-options="defaultOptions"
+    />
+  </PlBlockPage>
+</template>

--- a/ui/src/pages/HistogramPage.vue
+++ b/ui/src/pages/HistogramPage.vue
@@ -1,12 +1,16 @@
 <script setup lang="ts">
-import type { PredefinedGraphOption } from '@milaboratories/graph-maker';
+import type { GraphMakerProps, PredefinedGraphOption } from '@milaboratories/graph-maker';
 import { GraphMaker } from '@milaboratories/graph-maker';
 import { PlBlockPage } from '@platforma-sdk/ui-vue';
 import { useApp } from '../app';
+import type { PColumnIdAndSpec } from '@platforma-sdk/model';
+import { computed } from 'vue';
 
 const app = useApp();
 
-const defaultOptions: PredefinedGraphOption<'histogram'>[] = [
+// If there are two clonotype clustering blocks,
+// this way of specifying defaults is picking up the data from the previous clustering block.
+/* const defaultOptions: PredefinedGraphOption<'histogram'>[] = [
   {
     inputName: 'value',
     selectedSource: {
@@ -17,6 +21,27 @@ const defaultOptions: PredefinedGraphOption<'histogram'>[] = [
     },
   },
 ];
+ */
+
+// if there is no output or abundance spec, return undefined
+const defaultOptions = computed((): GraphMakerProps['defaultOptions'] => {
+  if (!app.model.outputs.clustersPfPcols)
+    return undefined;
+
+  const histPcols = app.model.outputs.clustersPfPcols;
+  function getIndex(name: string, pcols: PColumnIdAndSpec[]): number {
+    return pcols.findIndex((p) => (p.spec.name === name
+    ));
+  }
+  const defaults: PredefinedGraphOption<'histogram'>[] = [
+    {
+      inputName: 'value',
+      selectedSource: histPcols[getIndex('pl7.app/vdj/clustering/clusterSize',
+        histPcols)].spec,
+    },
+  ];
+  return defaults;
+});
 
 </script>
 
@@ -25,6 +50,7 @@ const defaultOptions: PredefinedGraphOption<'histogram'>[] = [
     <GraphMaker
       v-model="app.model.ui.graphStateHistogram"
       chartType="histogram"
+      :data-state-key="app.model.outputs.clustersPf"
       :p-frame="app.model.outputs.clustersPf"
       :default-options="defaultOptions"
     />

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -79,19 +79,21 @@ const tableLoadingText = computed(() => {
 
 const sequenceType = listToOptions(['aminoacid', 'nucleotide']);
 
+// Map user-facing similarity type to mmseqs2 similarity type
 const similarityTypeOptions = [
-  { label: 'Alignment Score', value: 'alignment-score' },
-  { label: 'Sequence Identity', value: 'sequence-identity' },
+  { label: 'BLOSUM', value: 'alignment-score' },
+  { label: 'Exact Match', value: 'sequence-identity' },
 ];
 
-const coverageModeOptions = [
+// No longer available to user
+/* const coverageModeOptions = [
   { label: 'Coverage of query and target', value: 0 },
   { label: 'Coverage of target', value: 1 },
   { label: 'Coverage of query', value: 2 },
   { label: 'Target length ≥ x% of query length', value: 3 },
   { label: 'Query length ≥ x% of target length', value: 4 },
   { label: 'Shorter sequence ≥ x% of longer', value: 5 },
-];
+]; */
 
 const isSequenceColumn = (column: PColumnIdAndSpec) => {
   return app.model.args.sequencesRef?.some((r) => r === column.columnId);
@@ -171,12 +173,22 @@ const clusterAxis = computed<AxisId>(() => {
         required
       />
 
+      <PlDropdown
+        v-model="app.model.args.similarityType"
+        :options="similarityTypeOptions"
+        label="Alignment Score"
+      >
+        <template #tooltip>
+          Type of alignment score used as threshold for clustering. BLOSUM accounts for amino acid similarity while Exact Match does not.
+        </template>
+      </PlDropdown>
+
       <PlNumberField
         v-model="app.model.args.identity"
         label="Minimal identity" :minValue="0.1" :step="0.1" :maxValue="1.0"
       >
         <template #tooltip>
-          Select min identity of clonotypes in the cluster.
+          Select min identity of clonotypes in the clusters.
         </template>
       </PlNumberField>
 
@@ -188,21 +200,12 @@ const clusterAxis = computed<AxisId>(() => {
         :maxValue="1.0"
       >
         <template #tooltip>
-          Select min fraction of aligned (covered) residues of clonotypes in the cluster.
+          Select min fraction of aligned (covered) residues of clonotypes in the clusters.
         </template>
       </PlNumberField>
 
-      <PlAccordionSection label="Advanced Settings">
-        <PlDropdown
-          v-model="app.model.args.similarityType"
-          :options="similarityTypeOptions"
-          label="Similarity Type"
-        >
-          <template #tooltip>
-            Type of similarity score used for clustering.
-          </template>
-        </PlDropdown>
-
+      <!-- Removed Advanced Settings -->
+<!--       <PlAccordionSection label="Advanced Settings">
         <PlDropdown
           v-model="app.model.args.coverageMode"
           :options="coverageModeOptions"
@@ -212,7 +215,7 @@ const clusterAxis = computed<AxisId>(() => {
             How to calculate the coverage between sequences for the coverage threshold.
           </template>
         </PlDropdown>
-      </PlAccordionSection>
+      </PlAccordionSection> -->
     </PlSlideModal>
   </PlBlockPage>
   <!-- Slide window with MSA -->

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -179,7 +179,7 @@ const clusterAxis = computed<AxisId>(() => {
         label="Alignment Score"
       >
         <template #tooltip>
-          Type of alignment score used as threshold for clustering. BLOSUM accounts for amino acid similarity while Exact Match does not.
+          Select the similarity metric used for clustering thresholds. BLOSUM considers biochemical similarity while Exact Match counts only identical residues.
         </template>
       </PlDropdown>
 
@@ -188,7 +188,7 @@ const clusterAxis = computed<AxisId>(() => {
         label="Minimal identity" :minValue="0.1" :step="0.1" :maxValue="1.0"
       >
         <template #tooltip>
-          Select min identity of clonotypes in the clusters.
+          Sets the lowest percentage of identical residues required for clonotypes to be considered for the same cluster.
         </template>
       </PlNumberField>
 
@@ -200,7 +200,7 @@ const clusterAxis = computed<AxisId>(() => {
         :maxValue="1.0"
       >
         <template #tooltip>
-          Select min fraction of aligned (covered) residues of clonotypes in the clusters.
+          Sets the lowest percentage of sequence length that must be covered for clonotypes to be considered for the same cluster.
         </template>
       </PlNumberField>
 

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -6,7 +6,6 @@ import type {
 } from '@platforma-sdk/ui-vue';
 import {
   listToOptions,
-  PlAccordionSection,
   PlAgDataTableToolsPanel,
   PlAgDataTableV2,
   PlBlockPage,
@@ -81,8 +80,8 @@ const sequenceType = listToOptions(['aminoacid', 'nucleotide']);
 
 // Map user-facing similarity type to mmseqs2 similarity type
 const similarityTypeOptions = [
-  { label: 'BLOSUM', value: 'alignment-score' },
   { label: 'Exact Match', value: 'sequence-identity' },
+  { label: 'BLOSUM', value: 'alignment-score' },
 ];
 
 // No longer available to user


### PR DESCRIPTION
- Added cluster size histogram
- Removed advanced settings panel and made clustering settings clearer
- Fixed plot defaults picking up data from previous block if there is another clonotype-clustering block upstream