### PR TITLE
Fix bug caused by mmseqs2 stripping fasta headers 

### DIFF
--- a/.changeset/proud-pans-invent.md
+++ b/.changeset/proud-pans-invent.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.clonotype-clustering.software': patch
+---
+
+Bug fix in mmseqs2 processing

--- a/software/src/prepare_fasta.py
+++ b/software/src/prepare_fasta.py
@@ -16,8 +16,8 @@ sequence_cols = [col for col in df.columns
                  if col.startswith('sequence_')]
 df['sequence'] = df[sequence_cols].agg("====".join, axis=1)
 
-# Reformat and store table in fasta format
-df['clonotypeKey'] = '>' + df['clonotypeKey'].astype(str)
+# Reformat and store table in fasta format, adding a fixed "s-" prefix.
+df['clonotypeKey'] = '>s-' + df['clonotypeKey'].astype(str)
 df[['clonotypeKey', 'sequence']].to_csv(output_file, 
                                         sep='\n', 
                                         index=False, 

--- a/software/src/process_results.py
+++ b/software/src/process_results.py
@@ -42,6 +42,14 @@ cloneTable = cloneTable.with_columns(
 clusters = pl.read_csv(clustersTsv, separator="\t", has_header=False,
                        new_columns=["clusterId", "clonotypeKey"])
 
+# Remove the "s-" prefix from clusterId and clonotypeKey. This prefix is added
+# during FASTA preparation for mmseqs and needs to be removed to match keys
+# in other tables like cloneTable.
+clusters = clusters.with_columns(
+    pl.col("clusterId").str.strip_prefix("s-"),
+    pl.col("clonotypeKey").str.strip_prefix("s-")
+)
+
 # --- Calculate cluster sizes directly in the clusters dataframe ---
 clusters = clusters.with_columns(
     pl.col('clonotypeKey').count().over('clusterId').alias('size')


### PR DESCRIPTION
Based on my investigation, the issue you're observing is likely due to how mmseqs parses FASTA headers. It appears to be interpreting the "uc" prefix in your clonotypeKey as a database identifier (similar to sp for Swiss-Prot or tr for TrEMBL) and is stripping it away. This is often a feature in bioinformatics tools to handle standard database formats, but in your case, it's causing an unintended truncation.

https://github.com/soedinglab/MMseqs2/issues/793#issuecomment-1871240398