### PR TITLE
MILAB-3015 add format annotations

### DIFF
--- a/.changeset/huge-hats-hope.md
+++ b/.changeset/huge-hats-hope.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.clonotype-clustering.workflow': minor
+---
+
+Add annotations for number formatting for distance to centroid

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -320,7 +320,8 @@ wf.body(func(args) {
 				annotations: {
 					"pl7.app/min": "0",
 					"pl7.app/max": "1",
-					"pl7.app/rankingOrder": "decreasing"
+					"pl7.app/rankingOrder": "decreasing",
+					"pl7.app/format": ".2f"
 				}
 			}, "Distance to centroid", false, undefined)
 		}]


### PR DESCRIPTION
Added number formatting annotation for distance to centroid. 
Not adding number formatting annotation for abundances because specs are inherited, should be added where the data is generated