### PR TITLE
MILAB-3578 Refactor out easy-cluster

### DIFF
--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -187,7 +187,9 @@ export const model = BlockModel.create()
     return createPlDataTableV2(ctx, pCols, ctx.uiState.tableState);
   })
 
-  .output('mmseqsOutput', (ctx) => ctx.outputs?.resolve('mmseqsOutput')?.getLogHandle())
+  .output('createDbLog', (ctx) => ctx.outputs?.resolve('createDbLog')?.getLogHandle())
+  .output('clusterLog', (ctx) => ctx.outputs?.resolve('clusterLog')?.getLogHandle())
+  .output('createTsvLog', (ctx) => ctx.outputs?.resolve('createTsvLog')?.getLogHandle())
 
   .output('msaPf', (ctx) => {
     const msaCols = ctx.outputs?.resolve('msaPf')?.getPColumns();

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -245,6 +245,11 @@ const clusterAxis = computed<AxisId>(() => {
   <!-- Slide window with MMseqs2 log -->
   <PlSlideModal v-model="mmseqsLogOpen" width="80%">
     <template #title>MMseqs2 Log</template>
-    <PlLogView :log-handle="app.model.outputs.mmseqsOutput"/>
+    <h4>DB creation</h4>
+    <PlLogView :log-handle="app.model.outputs.createDbLog"/>
+    <h4>Clustering</h4>
+    <PlLogView :log-handle="app.model.outputs.clusterLog"/>
+    <h4>Generate results table</h4>
+    <PlLogView :log-handle="app.model.outputs.createTsvLog"/>
   </PlSlideModal>
 </template>

--- a/workflow/src/clustering.tpl.tengo
+++ b/workflow/src/clustering.tpl.tengo
@@ -44,7 +44,7 @@ self.validateInputs({
     "cpu,?": "number"
 })
 
-self.defineOutputs("clustersPf", "bubblePlotPf", "msaPf", "pf", "clusterAbundanceSpec", "mmseqs", "mmseqsOutput", "isEmpty")
+self.defineOutputs("clustersPf", "bubblePlotPf", "msaPf", "pf", "clusterAbundanceSpec", "mmseqs", "isEmpty", "createDbLog", "clusterLog", "createTsvLog")
 
 self.body(func(inputs) {
     clustersPf := {}
@@ -53,7 +53,9 @@ self.body(func(inputs) {
     pf := {}
     clusterAbundanceSpec := {}
     mmseqs := {}
-    mmseqsOutput := {}
+    createDbLog := {}
+    clusterLog := {}
+    createTsvLog := {}
 	isEmpty := false
 
     seqTable := inputs.seqTable
@@ -76,7 +78,9 @@ self.body(func(inputs) {
             pf: pf,
             clusterAbundanceSpec: clusterAbundanceSpec,
             mmseqs: mmseqs,
-            mmseqsOutput: mmseqsOutput,
+            createDbLog: createDbLog,
+            clusterLog: clusterLog,
+            createTsvLog: createTsvLog,
 			isEmpty: true
 		}
 
@@ -121,9 +125,6 @@ self.body(func(inputs) {
 
 		inputDbFileSet := createDbResults.output("inputDbFileSet")
 		createDbStdout := createDbResults.output("stdout")
-
-        // @TODO: currently, this is the only log passed to model
-        mmseqsOutput := createDbStdout
 
         // mmseqs2 cluster runs the clustering and generates the cluster.db.* files
 		clusterResults := render.create(clusterTpl, {
@@ -520,7 +521,9 @@ self.body(func(inputs) {
 			// save mmseqs2 result in the output to enable deduplication of mmseqs2 run
 			// NOTE: mmseqs2 produces different results for same input (different line order)
 			mmseqs: clusters,
-			mmseqsOutput: mmseqsOutput,
+			createDbLog: createDbStdout,
+			clusterLog: clusterStdout,
+			createTsvLog: createTsvStdout,
 			isEmpty: false
 		}
 	} 

--- a/workflow/src/clustering.tpl.tengo
+++ b/workflow/src/clustering.tpl.tengo
@@ -8,7 +8,11 @@ maps := import("@platforma-sdk/workflow-tengo:maps")
 pSpec := import("@platforma-sdk/workflow-tengo:pframes.spec")
 text := import("text")
 slices := import("@platforma-sdk/workflow-tengo:slices")
+render := import("@platforma-sdk/workflow-tengo:render")
 
+createDbTpl := assets.importTemplate(":mmseqs-createdb")
+clusterTpl := assets.importTemplate(":mmseqs-cluster")
+createTsvTpl := assets.importTemplate(":mmseqs-createtsv")
 prepareFastaSw := assets.importSoftware("@platforma-open/milaboratories.clonotype-clustering.software:prepare-fasta")
 processResultsSw := assets.importSoftware("@platforma-open/milaboratories.clonotype-clustering.software:process-results")
 mmseqsSw := assets.importSoftware("@platforma-open/soedinglab.software-mmseqs2:main")
@@ -86,12 +90,11 @@ self.body(func(inputs) {
             addFile("input.tsv", seqTable).
             saveFile("output.fasta").
             run()
-
-        // get split memory limit based on real system ram
-	    memLimit := "{int(ceil(system.ram.gb * 0.8))}" + "G"
+		
+		fastaFile := fasta.getFile("output.fasta")
 
         mem := "32GiB" // @TODO: set based on the size of the input
-	    cpu := 16
+        cpu := 16
 
         if !is_undefined(inputs.mem) {
             mem = string(inputs.mem) + "GiB"
@@ -103,28 +106,49 @@ self.body(func(inputs) {
         // run mmseqs2
         // NOTE: mmseqs2 produces different results for same input (different line order),
         // so we save the result in the output to prevent CID conflict by deduplication
-        mmseqs := exec.builder().
-            software(mmseqsSw).
-            mem(mem).
-		    cpu(cpu).
-            printErrStreamToStdout(). 
-            arg("easy-cluster").
-            arg("input.fasta").
-            arg("result").
-            arg("tmp").
-            arg("--split-memory-limit").argWithVar(memLimit).
-            arg("--threads").argWithVar("{system.cpu}").
-            arg("--min-seq-id").arg(string(identity)).
-            arg("-c").arg(string(coverageThreshold)).
-            arg("--cov-mode").arg(string(coverageMode)).
-            //  --similarity-type INT            Type of score used for clustering. 1: alignment score 2: sequence identity [2]
-            arg("--similarity-type").arg(similarityType == "sequence-identity" ? "2" : "1").
-            addFile("input.fasta", fasta.getFile("output.fasta")).
-            saveFile("result_cluster.tsv").
-            run()
 
-        clusters := mmseqs.getFile("result_cluster.tsv")
-        mmseqsOutput := mmseqs.getStdoutStream()
+        // NOTE 2: For compatibility with windows, mmseqs easy-cluster command has been replaced with separate, 
+        // equivalent calls to mmseqs createdb, mmseqs2 cluster and mmseqs2 createtsv
+        // createdb and cluster generate variable numbers of db.x files (as many as threads) and
+        // currently for addFiles() to work, commands must be in separate templates.
+
+        // mmseqs createdb generates the database input.db.* search files
+		createDbResults := render.create(createDbTpl, {
+			fasta: fastaFile,
+			mem: mem,
+			cpu: cpu
+		})
+
+		inputDbFileSet := createDbResults.output("inputDbFileSet")
+		createDbStdout := createDbResults.output("stdout")
+
+        // @TODO: currently, this is the only log passed to model
+        mmseqsOutput := createDbStdout
+
+        // mmseqs2 cluster runs the clustering and generates the cluster.db.* files
+		clusterResults := render.create(clusterTpl, {
+			inputDbFileSet: inputDbFileSet,
+			identity: identity,
+			similarityType: similarityType,
+			coverageThreshold: coverageThreshold,
+			coverageMode: coverageMode,
+			mem: mem,
+			cpu: cpu
+		})
+
+		clusterDbFileSet := clusterResults.output("clusterDbFileSet")
+		clusterStdout := clusterResults.output("stdout")
+
+        // mmseqs2 createtsv generates the result_cluster.tsv with [centroid clonotypeId] to [clonotypeId] mapping
+		createTsvResults := render.create(createTsvTpl, {
+			inputDbFileSet: inputDbFileSet,
+			clusterDbFileSet: clusterDbFileSet,
+			mem: mem,
+			cpu: cpu
+		})
+
+		clusters := createTsvResults.output("clustersFile")
+		createTsvStdout := createTsvResults.output("stdout")
 
         /******* Step 2: aggregate all data and generate results *******/
         cloneTableBuilder := pframes.tsvFileBuilder()

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -133,7 +133,9 @@ wf.body(func(args) {
 	pf := clusteringAnalysis.output("pf", 24 * 60 * 60 * 1000)
 	clusterAbundanceSpec := clusteringAnalysis.output("clusterAbundanceSpec", 24 * 60 * 60 * 1000)
 	mmseqs := clusteringAnalysis.output("mmseqs", 24 * 60 * 60 * 1000)
-	mmseqsOutput := clusteringAnalysis.output("mmseqsOutput", 24 * 60 * 60 * 1000)
+	createDbLog := clusteringAnalysis.output("createDbLog", 24 * 60 * 60 * 1000)
+	clusterLog := clusteringAnalysis.output("clusterLog", 24 * 60 * 60 * 1000)
+	createTsvLog := clusteringAnalysis.output("createTsvLog", 24 * 60 * 60 * 1000)
 	isEmpty := clusteringAnalysis.output("isEmpty", 24 * 60 * 60 * 1000)
 
 	return {
@@ -152,7 +154,9 @@ wf.body(func(args) {
 			// save mmseqs2 result in the output to enable deduplication of mmseqs2 run
 			// NOTE: mmseqs2 produces different results for same input (different line order)
 			mmseqs: mmseqs,
-			mmseqsOutput: mmseqsOutput,
+			createDbLog: createDbLog,
+			clusterLog: clusterLog,
+			createTsvLog: createTsvLog,
 			isEmpty: isEmpty
 		},
 		exports: {

--- a/workflow/src/mmseqs-cluster.tpl.tengo
+++ b/workflow/src/mmseqs-cluster.tpl.tengo
@@ -1,0 +1,50 @@
+self := import("@platforma-sdk/workflow-tengo:tpl")
+exec := import("@platforma-sdk/workflow-tengo:exec")
+assets:= import("@platforma-sdk/workflow-tengo:assets")
+
+mmseqsSw := assets.importSoftware("@platforma-open/soedinglab.software-mmseqs2:main")
+
+self.validateInputs({
+    "__options__,closed": "",
+    inputDbFileSet: "any",
+    identity: "number",
+    similarityType: "string",
+    coverageThreshold: "number",
+    coverageMode: "number",
+    mem: "string",
+    cpu: "number"
+})
+
+self.defineOutputs("clusterDbFileSet", "stdout")
+
+self.body(func(inputs) {
+    // get split memory limit based on real system ram
+    memLimit := "{int(ceil(system.ram.gb * 0.8))}" + "G"
+
+    clusterRunBuilder := exec.builder().
+        software(mmseqsSw).
+        mem(inputs.mem).
+        cpu(inputs.cpu).
+        printErrStreamToStdout().
+        arg("cluster").
+        arg("input.db").
+        arg("cluster.db").
+        arg("tmp").
+        arg("--split-memory-limit").argWithVar(memLimit).
+        arg("--threads").argWithVar("{system.cpu}").
+        arg("--min-seq-id").arg(string(inputs.identity)).
+        arg("-c").arg(string(inputs.coverageThreshold)).
+        arg("--cov-mode").arg(string(inputs.coverageMode)).
+        //  --similarity-type INT (Type of score used for clustering. 1: alignment score 2: sequence identity [2]
+        arg("--similarity-type").arg(inputs.similarityType == "sequence-identity" ? "2" : "1").
+        addFiles(inputs.inputDbFileSet).
+        // Save all generated cluster.db.* files
+        saveFileSet("db", "^cluster\\.db.*")
+
+    clusterRun := clusterRunBuilder.run()
+
+    return {
+        clusterDbFileSet: clusterRun.getFileSet("db"),
+        stdout: clusterRun.getStdoutStream()
+    }
+})

--- a/workflow/src/mmseqs-createdb.tpl.tengo
+++ b/workflow/src/mmseqs-createdb.tpl.tengo
@@ -22,6 +22,8 @@ self.body(func(inputs) {
         arg("createdb").
         arg("input.fasta").
         arg("input.db").
+        arg("--shuffle").arg("1"). // Need this to match easy-cluster behavior
+        arg("--createdb-mode").arg("1"). // Need this to match easy-cluster behavior
         addFile("input.fasta", inputs.fasta).
         // Save all generated input.db.* files
         saveFileSet("db", "^input\\.db.*")

--- a/workflow/src/mmseqs-createdb.tpl.tengo
+++ b/workflow/src/mmseqs-createdb.tpl.tengo
@@ -1,0 +1,35 @@
+self := import("@platforma-sdk/workflow-tengo:tpl")
+exec := import("@platforma-sdk/workflow-tengo:exec")
+assets:= import("@platforma-sdk/workflow-tengo:assets")
+
+mmseqsSw := assets.importSoftware("@platforma-open/soedinglab.software-mmseqs2:main")
+
+self.validateInputs({
+    "__options__,closed": "",
+    fasta: "any",
+    mem: "string",
+    cpu: "number"
+})
+
+self.defineOutputs("inputDbFileSet", "stdout")
+
+self.body(func(inputs) {
+    createDbBuilder := exec.builder().
+        software(mmseqsSw).
+        mem(inputs.mem).
+        cpu(inputs.cpu).
+        printErrStreamToStdout().
+        arg("createdb").
+        arg("input.fasta").
+        arg("input.db").
+        addFile("input.fasta", inputs.fasta).
+        // Save all generated input.db.* files
+        saveFileSet("db", "^input\\.db.*")
+
+    createDb := createDbBuilder.run()
+
+    return {
+        inputDbFileSet: createDb.getFileSet("db"),
+        stdout: createDb.getStdoutStream()
+    }
+})

--- a/workflow/src/mmseqs-createtsv.tpl.tengo
+++ b/workflow/src/mmseqs-createtsv.tpl.tengo
@@ -1,0 +1,39 @@
+self := import("@platforma-sdk/workflow-tengo:tpl")
+exec := import("@platforma-sdk/workflow-tengo:exec")
+assets:= import("@platforma-sdk/workflow-tengo:assets")
+
+mmseqsSw := assets.importSoftware("@platforma-open/soedinglab.software-mmseqs2:main")
+
+self.validateInputs({
+    "__options__,closed": "",
+    inputDbFileSet: "any",
+    clusterDbFileSet: "any",
+    mem: "string",
+    cpu: "number"
+})
+
+self.defineOutputs("clustersFile", "stdout")
+
+self.body(func(inputs) {
+    createTsvBuilder := exec.builder().
+        software(mmseqsSw).
+        mem(inputs.mem).
+        cpu(inputs.cpu).
+        printErrStreamToStdout().
+        arg("createtsv").
+        arg("input.db").
+        arg("input.db"). 
+        arg("cluster.db").
+        arg("result_cluster.tsv").
+        arg("--threads").argWithVar("{system.cpu}").
+        addFiles(inputs.inputDbFileSet).
+        addFiles(inputs.clusterDbFileSet).
+        saveFile("result_cluster.tsv")
+        
+    createTsv := createTsvBuilder.run()
+
+    return {
+        clustersFile: createTsv.getFile("result_cluster.tsv"),
+        stdout: createTsv.getStdoutStream()
+    }
+})


### PR DESCRIPTION
This PR refactors the `mmseqs easy-cluster` command into three separate, equivalent calls: `mmseqs createdb`, `mmseqs cluster`, and `mmseqs createtsv`. This change was made to ensure compatibility with Windows environments as the `easy-cluster` workflow relies on a temporary `.sh` script that breaks on windows.

Because the `mmseqs createdb` and `mmseqs cluster` commands generate a variable number of `db.x` files (as many as threads), we need to use `saveFileSet()`, `getFileSet()` and `addFiles()`. Currently, this requires separating the `exec.builder()` of the commands into different templates so that when template is rendered these will resolved into a map that can be passed to `addFiles()` correctly in the next step.

The changes also include fixes to ensure that the output is identical to the original easy-cluster command and that logs for all three commands are correctly displayed.