### PR TITLE
Rename abundance columns to follow MiXCR's convention

### DIFF
--- a/.changeset/rename-abundance-columns.md
+++ b/.changeset/rename-abundance-columns.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.clonotype-clustering.workflow': minor
+---
+
+Rename per-sample fraction (`abundance_normalized`) to `pl7.app/vdj/readFraction` and per-cluster aggregates to `pl7.app/vdj/readCountTotal` / `pl7.app/vdj/readFractionTotal`, mirroring the naming convention used by `mixcr-clonotyping`. Without the per-sample fraction rename the column collided with its absolute-count sibling under PColumn identity (`kind+name+domain+axes`) and was silently deduped before reaching consumers — "Fraction Of Reads in Cluster" never appeared in Graph Maker's Y picker. The same renames apply to the UMI variant.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,14 +10,14 @@ catalogs:
       specifier: ^2.29.8
       version: 2.29.8
     '@milaboratories/graph-maker':
-      specifier: ^1.3.0
-      version: 1.3.0
+      specifier: 1.3.2
+      version: 1.3.2
     '@milaboratories/helpers':
       specifier: 1.14.1
       version: 1.14.1
     '@milaboratories/multi-sequence-alignment':
-      specifier: ^1.47.8
-      version: 1.47.8
+      specifier: 1.47.9
+      version: 1.47.9
     '@milaboratories/strings':
       specifier: 0.1.2
       version: 0.1.2
@@ -34,29 +34,29 @@ catalogs:
       specifier: 1.18.0
       version: 1.18.0
     '@platforma-sdk/block-tools':
-      specifier: 2.7.11
-      version: 2.7.11
+      specifier: 2.7.17
+      version: 2.7.17
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
     '@platforma-sdk/model':
-      specifier: 1.65.10
-      version: 1.65.10
+      specifier: 1.70.0
+      version: 1.70.0
     '@platforma-sdk/package-builder':
       specifier: 3.12.0
       version: 3.12.0
     '@platforma-sdk/tengo-builder':
-      specifier: 2.5.12
-      version: 2.5.12
+      specifier: 2.5.19
+      version: 2.5.19
     '@platforma-sdk/test':
-      specifier: 1.65.10
-      version: 1.65.10
+      specifier: 1.70.0
+      version: 1.70.0
     '@platforma-sdk/ui-vue':
-      specifier: 1.65.10
-      version: 1.65.10
+      specifier: 1.70.0
+      version: 1.70.0
     '@platforma-sdk/workflow-tengo':
-      specifier: 5.14.0
-      version: 5.14.0
+      specifier: 5.18.0
+      version: 5.18.0
     eslint:
       specifier: ^9.25.1
       version: 9.39.2
@@ -85,7 +85,7 @@ importers:
         version: 2.29.8(@types/node@24.5.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.11
+        version: 2.7.17
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -110,13 +110,13 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.11
+        version: 2.7.17
 
   model:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.3.0(@milaboratories/pl-model-common@1.34.0)(@platforma-sdk/model@1.65.10)(@platforma-sdk/ui-vue@1.65.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.3.2(@milaboratories/pl-model-common@1.37.0)(@platforma-sdk/model@1.70.0)(@platforma-sdk/ui-vue@1.70.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/helpers':
         specifier: 'catalog:'
         version: 1.14.1
@@ -125,7 +125,7 @@ importers:
         version: 0.1.2
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.65.10
+        version: 1.70.0
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
@@ -135,7 +135,7 @@ importers:
         version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.7.11
+        version: 2.7.17
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.39.2)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-n@17.15.1(eslint@9.39.2))(eslint-plugin-vue@9.32.0(eslint@9.39.2))(eslint@9.39.2)(globals@15.14.0)(typescript-eslint@8.24.0(eslint@9.39.2)(typescript@5.6.3))(typescript@5.6.3)
@@ -175,7 +175,7 @@ importers:
         version: 1.2.0(@eslint/js@9.39.2)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-n@17.15.1(eslint@9.39.2))(eslint-plugin-vue@9.32.0(eslint@9.39.2))(eslint@9.39.2)(globals@15.14.0)(typescript-eslint@8.24.0(eslint@9.39.2)(typescript@5.6.3))(typescript@5.6.3)
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.65.10(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
+        version: 1.70.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
       eslint:
         specifier: 'catalog:'
         version: 9.39.2
@@ -190,10 +190,10 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.3.0(@milaboratories/pl-model-common@1.34.0)(@platforma-sdk/model@1.65.10)(@platforma-sdk/ui-vue@1.65.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.3.2(@milaboratories/pl-model-common@1.37.0)(@platforma-sdk/model@1.70.0)(@platforma-sdk/ui-vue@1.70.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/multi-sequence-alignment':
         specifier: 'catalog:'
-        version: 1.47.8(@platforma-sdk/model@1.65.10)(@platforma-sdk/ui-vue@1.65.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.47.9(@platforma-sdk/model@1.70.0)(@platforma-sdk/ui-vue@1.70.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -202,10 +202,10 @@ importers:
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.65.10
+        version: 1.70.0
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.65.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+        version: 1.70.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       vue:
         specifier: 'catalog:'
         version: 3.5.25(typescript@5.6.3)
@@ -239,11 +239,11 @@ importers:
         version: 1.18.0
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 5.14.0
+        version: 5.18.0
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 2.5.12
+        version: 2.5.19
 
 packages:
 
@@ -1003,19 +1003,15 @@ packages:
   '@milaboratories/biowasm-tools@2.0.3':
     resolution: {integrity: sha512-/X2PJ9VYmVKHZ12X7p2lgzEN+zqeycatVGdVA1ifsdBXE4bKNmCrWhUr4JRlpoB5wuj/J5chBbIi6N9y6Tk1aw==}
 
-  '@milaboratories/computable@2.9.2':
-    resolution: {integrity: sha512-MXDXRqfJLV1dFK9PgMpdgRyixVAElnqAF0/CSGiyQ6e3+BhPtdmH+xpVz9HYR5cXe54VFQSUQlDTpNch4m4ERg==}
+  '@milaboratories/computable@2.9.3':
+    resolution: {integrity: sha512-xjt7BqaoWJ4g8CczYySnQTptSGgQIB3JNgeo3Bxvr9Dbk8FaLIGpq8xzwwgEbZuFqwnJzALfKp0gBKfmEVBmNw==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/graph-maker@1.3.0':
-    resolution: {integrity: sha512-Y3F7i/85BqNXZdhGox1NJmImrMq4OrWXT5S2LqIxiBWZsRN3Xj22ZllB80z5aBxQ9zmRFq4NLXWbEH60MY5UMg==}
+  '@milaboratories/graph-maker@1.3.2':
+    resolution: {integrity: sha512-bwi2d/NxEHU75/oUrW7msysioHwjH4O4TZtCR+ccM1tuT+iF17OAcbbUknUj1kBp8W2VTxB3r2DQpnv4YXiHgw==}
     peerDependencies:
       '@platforma-sdk/model': ^1.61.1
       '@platforma-sdk/ui-vue': ^1.61.1
-
-  '@milaboratories/helpers@1.13.5':
-    resolution: {integrity: sha512-BgwkcYrppMZzHyRpq6CgWZrns9zJr9ppSu+TIeJgozHQV+ufIujziyPttonWz2UmTVUEJh3/Q2TLp1bbbWKyNQ==}
-    engines: {node: '>=22'}
 
   '@milaboratories/helpers@1.14.1':
     resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
@@ -1024,88 +1020,94 @@ packages:
   '@milaboratories/miplots4@1.1.0':
     resolution: {integrity: sha512-ql4X2gh8pp18SJwcZVASO0F6xd7KEoOFrMQ10Ej8XokwqT17pu/YVj3YP4t1JAQBta9WCV80/s8BWvPyI6ul4Q==}
 
-  '@milaboratories/multi-sequence-alignment@1.47.8':
-    resolution: {integrity: sha512-t45pUuv9v3Ol9tXNJCoJWqjLi5RaB1i5psYHSFK7YYcZ1R42m5F/UYGo244BFFXNazc2HnzGugCpTGvKJ5hFbA==}
+  '@milaboratories/multi-sequence-alignment@1.47.9':
+    resolution: {integrity: sha512-MOFSJmNaM1b+9KKt4vPkYE7vuup4RBK1CpZcy+Mlbo9XVW7kfubh/N2a68Xc6vBrtbpie0TgHvsQ4NQgh3nYDQ==}
     peerDependencies:
       '@platforma-sdk/model': ^1.61.1
       '@platforma-sdk/ui-vue': ^1.61.1
 
-  '@milaboratories/pf-driver@1.3.9':
-    resolution: {integrity: sha512-y6FGvz4rA4JkBaS/y09k+9quDI/UybZZqLbeBGAPH2DRj0VBWXtrOO+SZqpogZhX0dlcVgNv0tcZ5aYXUqNZpA==}
+  '@milaboratories/pf-driver@1.4.3':
+    resolution: {integrity: sha512-0Takv2rkMS+B8nujUCHcwDXHl/KPDK/qoFWTuFHCqc15SIR0xy7vuQToHB7lHaDZd0bd4CXeA7CJm1pjuAYjGg==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pf-plots@1.2.0':
-    resolution: {integrity: sha512-FLtSW872ScOUZSWvceaqkQAmapc3s/vxn1tQixbUcUbX8GS7qybgU63daEZ1VtkfpaskP67NqkDVSCgaCABkDQ==}
+  '@milaboratories/pf-plots@1.2.1':
+    resolution: {integrity: sha512-XQWYhKVXrI1D1306mNtTWBhEtczBmGUiOZnBDmymzuZIl/FXZHRwW1aZt3XlWCYPj1h2kA9RZ6FSBc/CjPWFQg==}
     peerDependencies:
       '@milaboratories/pl-model-common': ^1.29.0
       '@platforma-sdk/model': ^1.61.1
 
-  '@milaboratories/pf-spec-driver@1.3.1':
-    resolution: {integrity: sha512-9gNh59iurbqpoO5UKr2AYguE++Kx29tGpFK6881SSthVkaZax0qUuHvzjXq2N5u1KCMUIgU4dsc390ELt39wSQ==}
+  '@milaboratories/pf-spec-driver@1.3.7':
+    resolution: {integrity: sha512-dkxGTgejPu6mf1FIEhByXktb34CqaJBrkefGFaHnrOklgRmIjYwQUKrHohzbLFx6HkRKpP0LluevvIXo4dDpvA==}
 
-  '@milaboratories/pframes-rs-node@1.1.26':
-    resolution: {integrity: sha512-RAsTcdPGLDz9h3NKu/VH1gdCZnEUvq+8cNrnjsuwOPHSXjvrd2XpjcOrHlmGZPvsGze6tX9MZ8i+Qrqo/r92cA==}
+  '@milaboratories/pframes-rs-node@1.1.31':
+    resolution: {integrity: sha512-TZkCDFrNiCH+1oRrpCzmD8GvlNky0W70YgGmIDJ/4Vi/Z0bMQQPlsB1OHOz7hfoySD9a0Djc1Q7lhnLmAtnPDA==}
 
-  '@milaboratories/pframes-rs-serv@1.1.26':
-    resolution: {integrity: sha512-bDh2Oj5642wicI66ZAZs8GtqmvuY0U/X0+zmBkfgNOXPfAsJ2At9LwuqfdeKROcv/A3rRzUkLH4xUAOzqNV1Bg==}
+  '@milaboratories/pframes-rs-serv@1.1.31':
+    resolution: {integrity: sha512-Cq/Q4H40bG4xYXNR9oJcDPZE+osMBJVdBnthxbZ0haYspoz7GWegEBW3EeeP/Aetp6G2jwMmPu/CGu/02O8X8g==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasm@1.1.26':
-    resolution: {integrity: sha512-lP56AHUj96WWlcEoKwMn0TIS/EVAOMkXVVS42G9fypV26tGbxrxSgOlcIgRpCpdR+s1r6yoy7/hx9u97Gxvorg==}
+  '@milaboratories/pframes-rs-wasi@1.1.31':
+    resolution: {integrity: sha512-pueH0fOgiCusD2YzlvZAD6FL1Qo2AvFc6+Jmxms+ymADgpTcd0ABYeaxGZih4hfgyJc5Zcnkea9dy+pemju8TA==}
+
+  '@milaboratories/pframes-rs-wasm@1.1.31':
+    resolution: {integrity: sha512-tLUf8FkRvrWOV6uSP1rwFlpNl0DUXkSNrrlTp5qFNFzHZSBtcVlw8bjfrJS7aCWuSMvKHQd49aNitEXF7aNbKw==}
     peerDependencies:
-      '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pl-model-common': 1.32.1
-      '@milaboratories/pl-model-middle-layer': 1.18.0
+      '@bytecodealliance/preview2-shim': 0.17.9
+      '@milaboratories/pl-model-common': 1.36.0
+      '@milaboratories/pl-model-middle-layer': 1.18.5
 
-  '@milaboratories/pl-client@3.1.5':
-    resolution: {integrity: sha512-7uPw8FbKwk0nPVmorZnRzJ5Ljqyi/fOzMh4BkFGGurY6D9Q372lhAAxQoRExmJO4X315zRB5G20wWRAAX9vkdQ==}
+  '@milaboratories/pl-client@3.2.3':
+    resolution: {integrity: sha512-+b0xzW7D5TEwm+CEaxS6tYoLykGObgLI6UVnDhx45J8jWBT6wJqXgilnlgBtHms66Xws5DqpFsO7eG8QyzCYXg==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-config@1.7.17':
-    resolution: {integrity: sha512-qqpgWAvKP/nL7GC9oBnAXLJwuib4johKqgKIrTkqiQE14B/HwjLebSAKTQUx9ya2/nDBZyjJbHeXvkmoWyqwrw==}
+  '@milaboratories/pl-config@1.7.18':
+    resolution: {integrity: sha512-l/RmLlFPuq7TyWHvdOc52Tv4Q2e2U+bEHwYasr+uAUfOrIJTXZ8umFQXeEX2u7A+GNrsX0mlvjzPrgXy2LH6Rw==}
 
-  '@milaboratories/pl-deployments@2.17.4':
-    resolution: {integrity: sha512-XGS6ahasPG0UmnqOqkBr128onjIGEx0Xzv1TxpdUpXfxDEVkOaVnZI0hUjlD4Y/qw90KxW110RNIgNloFKIriA==}
+  '@milaboratories/pl-deployments@2.17.10':
+    resolution: {integrity: sha512-jDb36Jt+DeAK+Qt+3bRQvJM/4s7LiMGlvwcKK9swhDaWpNWOi4SHeu9IezrxbiKlvOAu+mip7A3rbVHvMg86mA==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-drivers@1.12.16':
-    resolution: {integrity: sha512-vpP/CnRyDQn4DXYflWzU9ohB64xGxH6JOET8i2NUy46ClJGJlfu3DZEl9kn3puRr4RC1dmMketoWRgIX1J14HQ==}
+  '@milaboratories/pl-drivers@1.12.23':
+    resolution: {integrity: sha512-fmziWujCoWLXGdN0xwvccRZ4O/rW1SZHP58sU+LTizNsWlZA26aIzv+/JSOYBETrQ4AVZ24AHOJUpV2XZO5kvg==}
     engines: {node: '>=22'}
+
+  '@milaboratories/pl-error-like@1.12.10':
+    resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
   '@milaboratories/pl-error-like@1.12.9':
     resolution: {integrity: sha512-9qlfawLFO4qG656ayvVSRholhhwlfXUvKKllXpHadqbnf2zO2oCd+5J76bPaFXDz/A3T+1eokCnCX74JsqCYSw==}
 
-  '@milaboratories/pl-errors@1.3.4':
-    resolution: {integrity: sha512-8uBihSTqFhSo7KaUT8TiH1OoNkvlh0TbL5IwNuyZd76oP1+yY1VOjc85qekZG5IuwNZtBW+ZH8+9sp2Znn+aLw==}
+  '@milaboratories/pl-errors@1.3.11':
+    resolution: {integrity: sha512-/ZD8oVJtb303poBa8rjHcGYK64iG45Ji1pgvwQCXU0yD+8uNPHFiQ7kBfYMJUJ4y0AJfcYZMEQSl+25ZLkUtbA==}
 
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.55.19':
-    resolution: {integrity: sha512-gsWkrUgxhBOQcS31U0RvSSc10j6nmjQv7nGy1rs2pb/7X3epErzImDj2yNuZLaA3yBXwadO429EywtIFsfO6nw==}
+  '@milaboratories/pl-middle-layer@1.56.2':
+    resolution: {integrity: sha512-LiopOeLtRegBeJhUk/xQ+hedPDW8/9Tnn8Dr8FwUJLoivmkYzO5rt0PSLNpS3yUO5GhzK/2u12x9UlXktDmSEw==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-model-backend@1.2.12':
-    resolution: {integrity: sha512-fdKkxha4UVmXALbC2M8en2+N3x4fMJzZu8ZsE5up06d9m9wWP5PZW7s1oSyxdau3YvheOdjvu1WnCfGiR2hfuA==}
+  '@milaboratories/pl-model-backend@1.2.19':
+    resolution: {integrity: sha512-XEjadaXjudtftoUWqvFZIrsPKK1SAsimS8calVSzYyBxMqNhm7KCcds8XF8pcAR8ELG5tba/xKbAKxv9wCkqrw==}
 
-  '@milaboratories/pl-model-common@1.32.1':
-    resolution: {integrity: sha512-XFAJw2Re+YZ4rsgIupcNX8MlnsjU0kj53RA1LLBKps/9a5GmNadsN+vXuCaHv7TffGNweyba5gatih0Ek2AbsQ==}
+  '@milaboratories/pl-model-common@1.36.0':
+    resolution: {integrity: sha512-BbFs3sTmy12ZKfTY6rFep0C5pfQoLvsjACN8EYaNIjXqOjQajt6velh4uGpB47+Uyp78k0cIWH4T04MIlixQrw==}
 
-  '@milaboratories/pl-model-common@1.34.0':
-    resolution: {integrity: sha512-fTFMz2G5h3grOlqjmD6pWrSmHSt1rzy8j3IExrD6ZS3a5Pv+7J2t43sp0vv+EbcZGijoMeYVxsSLXfliFXH7gw==}
+  '@milaboratories/pl-model-common@1.37.0':
+    resolution: {integrity: sha512-r5HiU0O/j622589KXQSUlZlsBTkD7Xjc9WKeZldsZwlGNfTYQGjPUaCo3fNU4qgO1WYCflODfvwnJBIAiycK0A==}
 
-  '@milaboratories/pl-model-middle-layer@1.18.0':
-    resolution: {integrity: sha512-jtCXFydSA6W37a5TvJGe6UL3lrWDN9VwPx2ILqCS2ZBClypm5kqBbPiDs7Xz9zAglL5+K3XOI5opX+HmlB8CzA==}
+  '@milaboratories/pl-model-middle-layer@1.18.5':
+    resolution: {integrity: sha512-eIYE77rBva0k2KWDUmKJBHnGcyi/Tnc5rhlwZVb8q3hS3L4Upf4Pk7/lBL4ZLxYVMZ3/Da0Wp3EKYspUagi9Zg==}
 
-  '@milaboratories/pl-model-middle-layer@1.18.2':
-    resolution: {integrity: sha512-ULT84eS7qV8gAFNm0EaM7K8D91XvkjzL7M+H3jRscD2w4VUfb81dIK6n/4fGDrMDbS29NE5QUWwHPIUelElFUw==}
+  '@milaboratories/pl-model-middle-layer@1.18.8':
+    resolution: {integrity: sha512-srtGkQp58BS3AaIDP1sK5zhZE9jWAoUnJVYNPTcLGOHpnv/ChoilxTdpaIOl65gb7m9+vdfWEF5f5jeCJZVDVg==}
 
-  '@milaboratories/pl-tree@1.9.14':
-    resolution: {integrity: sha512-yD0nX9/+gce3yrqVjbW5aA8rLo5adFECTAYf7M33ASKdEHprlonwnXHcMRylMrT1fZqcZnY84uMPKtbyVtBWrw==}
+  '@milaboratories/pl-tree@1.9.21':
+    resolution: {integrity: sha512-2oOzwtf7H05lMZoZ6JQoOJa8l4FNjJQ1ivvBrUtAJa7cOmXmuZCMBj/epRl1WZAjQcPW1l3wUsvF0RlJPHL5Mg==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/ptabler-expression-js@1.2.12':
-    resolution: {integrity: sha512-nBTe+1UzFutdR0goe7lVjHwQ99LA3Mjt3Ln6Kp+CukV5ntCSeePYQBHG8IQGd2f5igdMgS2KPqN2M2RA3nkGPw==}
+  '@milaboratories/ptabler-expression-js@1.2.18':
+    resolution: {integrity: sha512-UftqmxiXWtOrxNMdX40dPXFnwfGZ9RrsOMebz19VUNxwDAhVpZ+YmcKnkgzOedH+pZTic6F86cYvIUp6+7EGHw==}
 
   '@milaboratories/resolve-helper@1.1.3':
     resolution: {integrity: sha512-38/dW/XRZQREOxAOOKtO0lzEWPCP/DH0qhB3q1kYcGoN++5V92/zbVwbYrMDeDcjTyo+D62iIep+sKXeWHa7Uw==}
@@ -1135,8 +1137,8 @@ packages:
     resolution: {integrity: sha512-eIDBzT9quzL3T7ivQn2BCKlsCqnCoSjtMSWSyFmdzPyDAY2OXb6sBjcYcSDdYLQAn2BANBEevii2Tp+WYAzIQw==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.12.6':
-    resolution: {integrity: sha512-CMoWqvXq5LnDguWlvSPUv39bv0Lf+04jo/BL2g5wFHIMQjjCx3kFGL9E9QDdxnWKoLq5YGBGqtNkPn/LsMe0vw==}
+  '@milaboratories/uikit@2.13.1':
+    resolution: {integrity: sha512-HNL4WJXBMz63Q7mZIizjWsCc80mFPfQWA8PeNCjKkxYf/kFmyupoL9Jrz8XWTxm3uVwjwKHHqzECXswQN74oDA==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -1384,11 +1386,11 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3@1.7.3':
     resolution: {integrity: sha512-PQQnh2Gb4EXN4afcKTj/H4HSlOvm03F24GRe2HwHQkKfZt8Td8jrDhO8AtMPQtSCbKDEKAQXMD0J2ybGXb6Vvg==}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.14.12':
-    resolution: {integrity: sha512-OyVXYBVic5jquIZu4KyGoN3OTHDrwAkxfFoxA2VTCdenEIS72rowpl58KVD46yYmAVa+6QG57hg+WtESE4WKDw==}
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.2':
+    resolution: {integrity: sha512-/VuhuJeXnk57SjwGVs+AYPUpApmoA0KWYa2Wih26QWq04H302XRpHsyFaD/5X4hkIL3XJU9+WC1Eu6HXZORg+A==}
 
-  '@platforma-open/milaboratories.software-ptabler@1.15.2':
-    resolution: {integrity: sha512-Tsb7+VldYyyp0m6kTT0Gzw67yX8WECLvgHkaCxCwjvSGpKlvjSjuFcBEPNZ7zjNoFdM7ZrtGu81xrrAVCrUuJw==}
+  '@platforma-open/milaboratories.software-ptabler@1.16.1':
+    resolution: {integrity: sha512-m4tzKYlopjHLYpRLSjIqEtFr0QP7MuweaMCTEmr6a+gIVE+x9MKawdXwNwo1A/2QuatygIcGRvIcIz34WibZMA==}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2':
     resolution: {integrity: sha512-I08YpKQ4+esLrfpVra5UJ+bznI9Zzba6OW0rKK407a1EUmanvYMVrCbM9gqnm6CHbv2vQxNGSaO8p1LoBh+9gA==}
@@ -1411,8 +1413,8 @@ packages:
   '@platforma-open/soedinglab.software-mmseqs2@1.18.0':
     resolution: {integrity: sha512-qZw1HPzF1TCjQXmckGUHK5o7/ErVomiY+Ink1Jj44GS8j+lG+LPoJvqVjtFSxUm9fCdzfQg6rCC78tbS/JiPpw==}
 
-  '@platforma-sdk/block-tools@2.7.11':
-    resolution: {integrity: sha512-w6G7LdnnzBNO0j1Uqg2mTzxTqfDQXm6Nd6otiWSXYMCylrRIhRenBeh9TLYxkcABK2MpP6rhgY+/woPdLAruTA==}
+  '@platforma-sdk/block-tools@2.7.17':
+    resolution: {integrity: sha512-Nx/1GYMwgfCftWoP2srz7DhadvrmW2/O2GrbY3Akwc0axSDFcXcF0mmMaBYwave3aoJCnWpasN+Sls1uXJetLg==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1431,26 +1433,26 @@ packages:
       typescript: ~5.6.3
       typescript-eslint: ^8.17.0
 
-  '@platforma-sdk/model@1.65.10':
-    resolution: {integrity: sha512-fvHaoJnyPraHebM7TEkz6k3NpV/aLWCt/ZZvG8dSNe2nmSrZL0OIuHRueaVxihQ/nMASoifb3qpv3zaxt6dVdA==}
+  '@platforma-sdk/model@1.70.0':
+    resolution: {integrity: sha512-yuJomPmQiBTBnLQQbhrcbIDaWa9fBRRbWDKFBLRNoWsN9BBTXcOGobQET1v6m8ln5Eed5b9yY4IktP0GPoW5HQ==}
 
   '@platforma-sdk/package-builder@3.12.0':
     resolution: {integrity: sha512-bId52YqV5iLDAn9D9C3xaLD1bKyymGpHe2CDEZTqV+1yWCBh1RM6iH96JIXudVJdcmJaqwJWDw6X4WzStE6SCg==}
     hasBin: true
 
-  '@platforma-sdk/tengo-builder@2.5.12':
-    resolution: {integrity: sha512-Ee4iW1dwhnfKAnZcDOiIaF3K0lUbEPfs5nRvhDYJ7U+VVQVoHBot7BQeeDK5gwz7Iq9Qukao3Mk0mlu5JBoahw==}
+  '@platforma-sdk/tengo-builder@2.5.19':
+    resolution: {integrity: sha512-GdnoG5Obkaj43PA02wn7ekICxHx+SSJhm79bJT8ojzEPDF4vdVVT/8HKC6OaAPPZ9k0sqsaynCR/Fk6G4mmJpw==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.65.10':
-    resolution: {integrity: sha512-qPgcrwORPs2atcSt+aCLXP9ztlniOx9ROyy4M7J3e8IJLLfWz6cofqUe3ZYfe5nUKakaGg5blayV4BD93q9MPg==}
+  '@platforma-sdk/test@1.70.0':
+    resolution: {integrity: sha512-6RVp2GY2wC5xFBG8YDDJhUNPkk5WR/YlpXHGuq1ouJ+5JOtleBIKsH2M3NcEh+Esw2CmpYyY6I0RorMGX/4Yng==}
 
-  '@platforma-sdk/ui-vue@1.65.10':
-    resolution: {integrity: sha512-4Wl3RSXGH9mqsK2i0C/tR8t259AQR4IQQX6IMCzmYa61C2QdhMYW4Pt3p8OgcF7680GDG7lG2QGt0CkO+o/sgQ==}
+  '@platforma-sdk/ui-vue@1.70.0':
+    resolution: {integrity: sha512-pq4o4xzWVdtckutB5seOJTjTvIIyAbO/oeCzbLCWGrhQ1iBV9d6+TRfbo40yi1cJrcLXdOXuBMc1rhOX0fZhyg==}
 
-  '@platforma-sdk/workflow-tengo@5.14.0':
-    resolution: {integrity: sha512-4k/1/TNQBoQGCfLLQsS2AzYLNdsERcdyFA7Y6pryGm+4OotG5pqU5trjGMeiTBDn2OiGYgBy8cLAHQ0JysK65Q==}
+  '@platforma-sdk/workflow-tengo@5.18.0':
+    resolution: {integrity: sha512-Jas0Vv2c1rqxVLJos4col7T54N5fZAaz34c7uGGP52buomDiBA4GEbBKd5aEzx9VIr3kthcuW3QP09YqJjpp8w==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -7358,21 +7360,21 @@ snapshots:
 
   '@milaboratories/biowasm-tools@2.0.3': {}
 
-  '@milaboratories/computable@2.9.2':
+  '@milaboratories/computable@2.9.3':
     dependencies:
-      '@milaboratories/pl-error-like': 1.12.9
+      '@milaboratories/pl-error-like': 1.12.10
       '@milaboratories/ts-helpers': 1.8.1
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
-  '@milaboratories/graph-maker@1.3.0(@milaboratories/pl-model-common@1.34.0)(@platforma-sdk/model@1.65.10)(@platforma-sdk/ui-vue@1.65.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/graph-maker@1.3.2(@milaboratories/pl-model-common@1.37.0)(@platforma-sdk/model@1.70.0)(@platforma-sdk/ui-vue@1.70.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.5
       '@milaboratories/helpers': 1.14.1
       '@milaboratories/miplots4': 1.1.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.2.0(@milaboratories/pl-model-common@1.34.0)(@platforma-sdk/model@1.65.10)
-      '@platforma-sdk/model': 1.65.10
-      '@platforma-sdk/ui-vue': 1.65.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/pf-plots': 1.2.1(@milaboratories/pl-model-common@1.37.0)(@platforma-sdk/model@1.70.0)
+      '@platforma-sdk/model': 1.70.0
+      '@platforma-sdk/ui-vue': 1.70.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@types/d3-hierarchy': 3.1.7
       '@types/d3-scale': 4.0.9
       '@vueuse/core': 13.4.0(vue@3.5.25(typescript@5.6.3))
@@ -7388,8 +7390,6 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
       - typescript
-
-  '@milaboratories/helpers@1.13.5': {}
 
   '@milaboratories/helpers@1.14.1': {}
 
@@ -7424,19 +7424,19 @@ snapshots:
       rbush: 4.0.1
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      zod: 3.23.8
+      zod: 3.25.76
     transitivePeerDependencies:
       - d3-dispatch
       - d3-path
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/multi-sequence-alignment@1.47.8(@platforma-sdk/model@1.65.10)(@platforma-sdk/ui-vue@1.65.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/multi-sequence-alignment@1.47.9(@platforma-sdk/model@1.70.0)(@platforma-sdk/ui-vue@1.70.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@milaboratories/biowasm-tools': 2.0.3
       '@milaboratories/miplots4': 1.1.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@platforma-sdk/model': 1.65.10
-      '@platforma-sdk/ui-vue': 1.65.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@platforma-sdk/model': 1.70.0
+      '@platforma-sdk/ui-vue': 1.70.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       vue: 3.5.25(typescript@5.6.3)
     transitivePeerDependencies:
       - d3-dispatch
@@ -7445,13 +7445,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@milaboratories/pf-driver@1.3.9(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-driver@1.4.3(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pframes-rs-node': 1.1.26
-      '@milaboratories/pframes-rs-wasm': 1.1.26(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.34.0)(@milaboratories/pl-model-middle-layer@1.18.2)
-      '@milaboratories/pl-model-common': 1.34.0
-      '@milaboratories/pl-model-middle-layer': 1.18.2
+      '@milaboratories/pframes-rs-node': 1.1.31
+      '@milaboratories/pframes-rs-wasm': 1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.37.0)(@milaboratories/pl-model-middle-layer@1.18.8)
+      '@milaboratories/pl-model-common': 1.37.0
+      '@milaboratories/pl-model-middle-layer': 1.18.8
       '@milaboratories/ts-helpers': 1.8.1
       es-toolkit: 1.39.10
       lru-cache: 11.2.2
@@ -7460,53 +7460,56 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-plots@1.2.0(@milaboratories/pl-model-common@1.34.0)(@platforma-sdk/model@1.65.10)':
+  '@milaboratories/pf-plots@1.2.1(@milaboratories/pl-model-common@1.37.0)(@platforma-sdk/model@1.70.0)':
     dependencies:
-      '@milaboratories/pl-model-common': 1.34.0
-      '@platforma-sdk/model': 1.65.10
+      '@milaboratories/pl-model-common': 1.37.0
+      '@platforma-sdk/model': 1.70.0
       canonicalize: 2.1.0
       lodash: 4.17.21
 
-  '@milaboratories/pf-spec-driver@1.3.1(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-spec-driver@1.3.7(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pframes-rs-wasm': 1.1.26(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.34.0)(@milaboratories/pl-model-middle-layer@1.18.2)
-      '@milaboratories/pl-model-common': 1.34.0
-      '@milaboratories/pl-model-middle-layer': 1.18.2
+      '@milaboratories/pframes-rs-wasm': 1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.37.0)(@milaboratories/pl-model-middle-layer@1.18.8)
+      '@milaboratories/pl-model-common': 1.37.0
+      '@milaboratories/pl-model-middle-layer': 1.18.8
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
 
-  '@milaboratories/pframes-rs-node@1.1.26':
+  '@milaboratories/pframes-rs-node@1.1.31':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
-      '@milaboratories/helpers': 1.13.5
-      '@milaboratories/pframes-rs-serv': 1.1.26
-      '@milaboratories/pl-model-common': 1.32.1
+      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/pframes-rs-serv': 1.1.31
+      '@milaboratories/pl-model-common': 1.36.0
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.26':
+  '@milaboratories/pframes-rs-serv@1.1.31':
     dependencies:
-      '@milaboratories/helpers': 1.13.5
-      '@milaboratories/pl-model-common': 1.32.1
-      '@milaboratories/pl-model-middle-layer': 1.18.0
+      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/pl-model-common': 1.36.0
+      '@milaboratories/pl-model-middle-layer': 1.18.5
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasm@1.1.26(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.34.0)(@milaboratories/pl-model-middle-layer@1.18.2)':
+  '@milaboratories/pframes-rs-wasi@1.1.31': {}
+
+  '@milaboratories/pframes-rs-wasm@1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.37.0)(@milaboratories/pl-model-middle-layer@1.18.8)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pl-model-common': 1.34.0
-      '@milaboratories/pl-model-middle-layer': 1.18.2
+      '@milaboratories/pframes-rs-wasi': 1.1.31
+      '@milaboratories/pl-model-common': 1.37.0
+      '@milaboratories/pl-model-middle-layer': 1.18.8
 
-  '@milaboratories/pl-client@3.1.5':
+  '@milaboratories/pl-client@3.2.3':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.34.0
+      '@milaboratories/pl-model-common': 1.37.0
       '@milaboratories/ts-helpers': 1.8.1
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
@@ -7520,17 +7523,17 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.1
 
-  '@milaboratories/pl-config@1.7.17':
+  '@milaboratories/pl-config@1.7.18':
     dependencies:
       '@milaboratories/ts-helpers': 1.8.1
       upath: 2.0.1
       yaml: 2.8.1
 
-  '@milaboratories/pl-deployments@2.17.4':
+  '@milaboratories/pl-deployments@2.17.10':
     dependencies:
-      '@milaboratories/pl-config': 1.7.17
+      '@milaboratories/pl-config': 1.7.18
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.34.0
+      '@milaboratories/pl-model-common': 1.37.0
       '@milaboratories/ts-helpers': 1.8.1
       decompress: 4.2.1
       ssh2: 1.16.0
@@ -7540,14 +7543,14 @@ snapshots:
       yaml: 2.8.1
       zod: 3.25.76
 
-  '@milaboratories/pl-drivers@1.12.16':
+  '@milaboratories/pl-drivers@1.12.23':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@milaboratories/computable': 2.9.2
+      '@milaboratories/computable': 2.9.3
       '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-client': 3.1.5
-      '@milaboratories/pl-model-common': 1.34.0
-      '@milaboratories/pl-tree': 1.9.14
+      '@milaboratories/pl-client': 3.2.3
+      '@milaboratories/pl-model-common': 1.37.0
+      '@milaboratories/pl-tree': 1.9.21
       '@milaboratories/ts-helpers': 1.8.1
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/plugin': 2.11.1
@@ -7562,14 +7565,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@milaboratories/pl-error-like@1.12.10':
+    dependencies:
+      json-stringify-safe: 5.0.1
+      zod: 3.25.76
+
   '@milaboratories/pl-error-like@1.12.9':
     dependencies:
       json-stringify-safe: 5.0.1
       zod: 3.23.8
 
-  '@milaboratories/pl-errors@1.3.4':
+  '@milaboratories/pl-errors@1.3.11':
     dependencies:
-      '@milaboratories/pl-client': 3.1.5
+      '@milaboratories/pl-client': 3.2.3
       '@milaboratories/ts-helpers': 1.8.1
       zod: 3.25.76
 
@@ -7577,28 +7585,28 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.55.19(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pl-middle-layer@1.56.2(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/computable': 2.9.2
+      '@milaboratories/computable': 2.9.3
       '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pf-driver': 1.3.9(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pf-spec-driver': 1.3.1(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pframes-rs-node': 1.1.26
-      '@milaboratories/pframes-rs-wasm': 1.1.26(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.34.0)(@milaboratories/pl-model-middle-layer@1.18.2)
-      '@milaboratories/pl-client': 3.1.5
-      '@milaboratories/pl-deployments': 2.17.4
-      '@milaboratories/pl-drivers': 1.12.16
-      '@milaboratories/pl-errors': 1.3.4
+      '@milaboratories/pf-driver': 1.4.3(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.3.7(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pframes-rs-node': 1.1.31
+      '@milaboratories/pframes-rs-wasm': 1.1.31(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.37.0)(@milaboratories/pl-model-middle-layer@1.18.8)
+      '@milaboratories/pl-client': 3.2.3
+      '@milaboratories/pl-deployments': 2.17.10
+      '@milaboratories/pl-drivers': 1.12.23
+      '@milaboratories/pl-errors': 1.3.11
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.2.12
-      '@milaboratories/pl-model-common': 1.34.0
-      '@milaboratories/pl-model-middle-layer': 1.18.2
-      '@milaboratories/pl-tree': 1.9.14
+      '@milaboratories/pl-model-backend': 1.2.19
+      '@milaboratories/pl-model-common': 1.37.0
+      '@milaboratories/pl-model-middle-layer': 1.18.8
+      '@milaboratories/pl-tree': 1.9.21
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.1
-      '@platforma-sdk/block-tools': 2.7.11
-      '@platforma-sdk/model': 1.65.10
-      '@platforma-sdk/workflow-tengo': 5.14.0
+      '@platforma-sdk/block-tools': 2.7.17
+      '@platforma-sdk/model': 1.70.0
+      '@platforma-sdk/workflow-tengo': 5.18.0
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.39.10
@@ -7614,55 +7622,55 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pl-model-backend@1.2.12':
+  '@milaboratories/pl-model-backend@1.2.19':
     dependencies:
-      '@milaboratories/pl-client': 3.1.5
+      '@milaboratories/pl-client': 3.2.3
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.32.1':
+  '@milaboratories/pl-model-common@1.36.0':
     dependencies:
       '@milaboratories/helpers': 1.14.1
       '@milaboratories/pl-error-like': 1.12.9
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.34.0':
+  '@milaboratories/pl-model-common@1.37.0':
     dependencies:
       '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-error-like': 1.12.9
+      '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.18.0':
+  '@milaboratories/pl-model-middle-layer@1.18.5':
     dependencies:
       '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.32.1
+      '@milaboratories/pl-model-common': 1.36.0
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.18.2':
+  '@milaboratories/pl-model-middle-layer@1.18.8':
     dependencies:
       '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.34.0
+      '@milaboratories/pl-model-common': 1.37.0
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-tree@1.9.14':
+  '@milaboratories/pl-tree@1.9.21':
     dependencies:
-      '@milaboratories/computable': 2.9.2
-      '@milaboratories/pl-client': 3.1.5
-      '@milaboratories/pl-errors': 1.3.4
+      '@milaboratories/computable': 2.9.3
+      '@milaboratories/pl-client': 3.2.3
+      '@milaboratories/pl-errors': 1.3.11
       '@milaboratories/ts-helpers': 1.8.1
       denque: 2.1.0
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/ptabler-expression-js@1.2.12':
+  '@milaboratories/ptabler-expression-js@1.2.18':
     dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.14.12
+      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.2
 
   '@milaboratories/resolve-helper@1.1.3': {}
 
@@ -7681,7 +7689,7 @@ snapshots:
       oxfmt: 0.35.0
       oxlint: 1.43.0
       rolldown: 1.0.0-rc.17
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.5.2)(rollup@4.53.5)
       typescript: 5.9.3
@@ -7725,10 +7733,10 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.12.6(typescript@5.6.3)':
+  '@milaboratories/uikit@2.13.1(typescript@5.6.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.1
-      '@platforma-sdk/model': 1.65.10
+      '@platforma-sdk/model': 1.70.0
       '@types/d3-array': 3.2.1
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -7999,11 +8007,11 @@ snapshots:
       '@platforma-open/milaboratories.runenv-python-3.12.10-rapids': 1.4.2
       '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda': 1.3.3
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.14.12':
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.2':
     dependencies:
-      '@milaboratories/pl-model-common': 1.34.0
+      '@milaboratories/pl-model-common': 1.37.0
 
-  '@platforma-open/milaboratories.software-ptabler@1.15.2': {}
+  '@platforma-open/milaboratories.software-ptabler@1.16.1': {}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2': {}
 
@@ -8024,12 +8032,12 @@ snapshots:
 
   '@platforma-open/soedinglab.software-mmseqs2@1.18.0': {}
 
-  '@platforma-sdk/block-tools@2.7.11':
+  '@platforma-sdk/block-tools@2.7.17':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.34.0
-      '@milaboratories/pl-model-middle-layer': 1.18.2
+      '@milaboratories/pl-model-common': 1.37.0
+      '@milaboratories/pl-model-middle-layer': 1.18.8
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.1
       '@milaboratories/ts-helpers-oclif': 1.1.40
@@ -8060,13 +8068,13 @@ snapshots:
       typescript: 5.6.3
       typescript-eslint: 8.24.0(eslint@9.39.2)(typescript@5.6.3)
 
-  '@platforma-sdk/model@1.65.10':
+  '@platforma-sdk/model@1.70.0':
     dependencies:
       '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-error-like': 1.12.9
-      '@milaboratories/pl-model-common': 1.34.0
-      '@milaboratories/pl-model-middle-layer': 1.18.2
-      '@milaboratories/ptabler-expression-js': 1.2.12
+      '@milaboratories/pl-error-like': 1.12.10
+      '@milaboratories/pl-model-common': 1.37.0
+      '@milaboratories/pl-model-middle-layer': 1.18.8
+      '@milaboratories/ptabler-expression-js': 1.2.18
       canonicalize: 2.1.0
       es-toolkit: 1.39.10
       fast-json-patch: 3.1.1
@@ -8089,22 +8097,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@platforma-sdk/tengo-builder@2.5.12':
+  '@platforma-sdk/tengo-builder@2.5.19':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.2.12
+      '@milaboratories/pl-model-backend': 1.2.19
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
       '@milaboratories/ts-helpers': 1.8.1
       '@oclif/core': 4.2.6
       winston: 3.17.0
 
-  '@platforma-sdk/test@1.65.10(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))':
+  '@platforma-sdk/test@1.70.0(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))':
     dependencies:
-      '@milaboratories/computable': 2.9.2
-      '@milaboratories/pl-client': 3.1.5
-      '@milaboratories/pl-middle-layer': 1.55.19(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-tree': 1.9.14
-      '@platforma-sdk/model': 1.65.10
+      '@milaboratories/computable': 2.9.3
+      '@milaboratories/pl-client': 3.2.3
+      '@milaboratories/pl-middle-layer': 1.56.2(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-tree': 1.9.21
+      '@platforma-sdk/model': 1.70.0
       '@vitest/coverage-istanbul': 4.1.5(vitest@4.1.5)
       vitest: 4.1.5(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.5(vitest@4.0.8(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1)))(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
     transitivePeerDependencies:
@@ -8125,12 +8133,12 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.65.10(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
+  '@platforma-sdk/ui-vue@1.70.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.3.1(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-model-common': 1.34.0
-      '@milaboratories/uikit': 2.12.6(typescript@5.6.3)
-      '@platforma-sdk/model': 1.65.10
+      '@milaboratories/pf-spec-driver': 1.3.7(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-model-common': 1.37.0
+      '@milaboratories/uikit': 2.13.1(typescript@5.6.3)
+      '@platforma-sdk/model': 1.70.0
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.0
@@ -8161,10 +8169,10 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@5.14.0':
+  '@platforma-sdk/workflow-tengo@5.18.0':
     dependencies:
       '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 1.15.2
+      '@platforma-open/milaboratories.software-ptabler': 1.16.1
       '@platforma-open/milaboratories.software-ptexter': 1.2.2
       '@platforma-open/milaboratories.software-small-binaries': 2.0.4
 
@@ -12863,7 +12871,7 @@ snapshots:
     dependencies:
       glob: 10.4.5
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
@@ -13409,11 +13417,11 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.2
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 8.0.10(@types/node@24.5.2)(yaml@2.8.1)
       why-is-node-running: 2.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,20 +10,20 @@ catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
   '@milaboratories/ts-builder': 1.3.2
   '@milaboratories/ts-configs': 1.2.3
-  '@platforma-sdk/workflow-tengo': 5.14.0
-  '@platforma-sdk/model': 1.65.10
-  '@platforma-sdk/ui-vue': 1.65.10
-  '@platforma-sdk/tengo-builder': 2.5.12
+  '@platforma-sdk/workflow-tengo': 5.18.0
+  '@platforma-sdk/model': 1.70.0
+  '@platforma-sdk/ui-vue': 1.70.0
+  '@platforma-sdk/tengo-builder': 2.5.19
   '@platforma-sdk/package-builder': 3.12.0
-  '@platforma-sdk/block-tools': 2.7.11
+  '@platforma-sdk/block-tools': 2.7.17
   '@platforma-sdk/eslint-config': 1.2.0
-  '@platforma-sdk/test': 1.65.10
+  '@platforma-sdk/test': 1.70.0
   '@milaboratories/helpers': 1.14.1
   '@milaboratories/strings': 0.1.2
 
   # Block-specific dependencies
-  '@milaboratories/graph-maker': ^1.3.0
-  '@milaboratories/multi-sequence-alignment': '^1.47.8'
+  '@milaboratories/graph-maker': 1.3.2
+  '@milaboratories/multi-sequence-alignment': '1.47.9'
   '@milaboratories/software-pframes-conv': ^2.2.9
   '@platforma-open/milaboratories.runenv-python-3': ^1.7.3
   '@platforma-open/soedinglab.software-mmseqs2': 1.18.0

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -210,6 +210,22 @@ wf.body(func(args) {
 
 	abundanceLabel := abundanceSpec.annotations["pl7.app/label"]
 
+	// Distinct names per (aggregation level x count/fraction). Same kind+name+domain+axes
+	// PColumns get silently deduped by PColumnCollection (valueType and annotations aren't
+	// part of identity), so siblings that differ only in valueType/normalized must use
+	// different names. Names also follow MiXCR's convention: per-clonotype aggregates use
+	// "Total" (e.g. readCountTotal); we mirror that for per-cluster aggregates.
+	fractionName := "pl7.app/vdj/readFraction"
+	totalCountName := "pl7.app/vdj/readCountTotal"
+	totalFractionName := "pl7.app/vdj/readFractionTotal"
+	abundanceUnit := "reads"
+	if text.contains(ac.name, "uniqueMoleculeCount") {
+		fractionName = "pl7.app/vdj/uniqueMoleculeFraction"
+		totalCountName = "pl7.app/vdj/uniqueMoleculeCountTotal"
+		totalFractionName = "pl7.app/vdj/uniqueMoleculeFractionTotal"
+		abundanceUnit = "molecules"
+	}
+
 	// De-anonymize TSV files that contain sampleId
 	// Run deanonymization as ephemeral to avoid cross-project deduplication while keeping
 	// clustering computation cached. This ensures mapping is applied per project.
@@ -237,9 +253,11 @@ wf.body(func(args) {
 		{
 			column: "abundance_normalized",
 			spec: setTableProps(maps.deepMerge(ac, {
+				name: fractionName,
 				valueType: "Float",
 				annotations: {
-					"pl7.app/abundance/normalized": "true"
+					"pl7.app/abundance/normalized": "true",
+					"pl7.app/abundance/unit": abundanceUnit
 				}
 			}), text.re_replace("Number", abundanceLabel, "Fraction") + " in Cluster", false, undefined)
 		}],
@@ -254,24 +272,15 @@ wf.body(func(args) {
 		}],
 		columns: [{
 			column: "abundance_per_cluster",
-			spec: setTableProps(ac, "Total " + abundanceLabel + " in Cluster", true, "2000")
+			spec: setTableProps(maps.deepMerge(ac, {
+				name: totalCountName
+			}), "Total " + abundanceLabel + " in Cluster", true, "2000")
 		},
 		{
 			column: "abundance_fraction_per_cluster",
 			spec: func() {
-				// Determine fraction name and unit based on abundance type
-				fractionName := "pl7.app/vdj/readFraction"
-				abundanceUnit := "reads"
-				if text.contains(ac.name, "uniqueMoleculeCount") {
-					fractionName = "pl7.app/vdj/uniqueMoleculeFraction"
-					abundanceUnit = "molecules"
-				} else if text.contains(ac.name, "readCount") {
-					fractionName = "pl7.app/vdj/readFraction"
-					abundanceUnit = "reads"
-				}
-				
 				abundanceFractionSpec := maps.deepMerge(ac, {
-					name: fractionName,
+					name: totalFractionName,
 					valueType: "Float",
 					annotations: {
 						"pl7.app/abundance/isPrimary": "true",


### PR DESCRIPTION
The block emits four abundance columns: per-sample-per-cluster count + fraction (axes `[sampleId, clusterId]`) and per-cluster aggregate count + fraction (axes `[clusterId]`). Three of them shared a name with another column in the same pframe, differing only in `valueType` or annotations:

| Column | Was | Now |
|---|---|---|
| per-sample fraction (`abundance_normalized`) | `pl7.app/vdj/readCount` (Float) | `pl7.app/vdj/readFraction` |
| per-cluster total count (`abundance_per_cluster`) | `pl7.app/vdj/readCount` (Long, axes=[clusterId]) | `pl7.app/vdj/readCountTotal` |
| per-cluster total fraction (`abundance_fraction_per_cluster`) | `pl7.app/vdj/readFraction` (Float) | `pl7.app/vdj/readFractionTotal` |

PColumn identity is keyed on `kind+name+domain+axes` — `valueType` and annotations are not part of it. The per-sample fraction collided with its absolute-count sibling under `PColumnCollection`'s `nativeId` dedup and was silently dropped before reaching Graph Maker; "Fraction Of Reads in Cluster" never appeared in the Y picker for users with Clonotype Clustering in their project. The two aggregate columns didn't collide (different axes), but they reused per-sample names, which `mixcr-clonotyping` avoids by using `readCountTotal` / `readFractionMean` for its own per-clonotype aggregates. We mirror that pattern for clusters (`Total` rather than `Mean` because the cluster aggregate is a sum, not an average).

The same renames apply to the UMI variant (`uniqueMoleculeCount` / `uniqueMoleculeFraction` / `uniqueMoleculeCountTotal` / `uniqueMoleculeFractionTotal`), and the per-sample/aggregate name selection is now lifted into one shared block so the four stay aligned.

## Deferred (not in this PR)

Annotation polish to bring the four columns fully in line with `mixcr-clonotyping`'s per-sample/aggregate spec, intentionally out of scope so this stays a focused naming change:

- **Per-sample fraction (`abundance_normalized`)** — inherits from the count column today: `pl7.app/min` should be `"0"` (not `"1"`); add `pl7.app/max: "1"` and `pl7.app/format: ".2p"`; drop the inherited `pl7.app/isAnchor: "true"` (only the absolute-count sibling is the anchor).
- **Per-cluster total count (`abundance_per_cluster`)** — inherits `pl7.app/abundance/isPrimary: "true"` and `pl7.app/isAnchor: "true"`; both should be removed (the per-sample count is the primary anchor, the aggregate is derived).
- **Per-cluster total fraction (`abundance_fraction_per_cluster`)** — explicitly sets `pl7.app/abundance/isPrimary: "true"`, should be removed for the same reason.

## SDK angle (separate concern)

`deriveNativeId` in `pl-model-common` (`drivers/pframe/spec/native_id.ts`) builds identity from `kind + name + domain + contextDomain + axesId`. As long as that's the contract, blocks must use distinct names for siblings that differ only in `valueType` or normalization. Worth considering a follow-up there to make `PColumnCollection` warn (rather than silently drop) when nativeId collisions arise — would have caught this bug at write time.