### PR TITLE
[TEST – DO NOT MERGE] Verify github-ci#166 surfaces both preflight gates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
   run:
     needs:
       - init
-    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4-beta
+    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@paulnewling/preflight-cleanup
     with:
       app-name: 'Block: Clonotype Clustering'
       app-name-slug: 'block-clonotype-clustering'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
   run:
     needs:
       - init
-    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4
+    uses: milaboratory/github-ci/.github/workflows/node-simple-pnpm.yaml@v4-beta
     with:
       app-name: 'Block: Clonotype Clustering'
       app-name-slug: 'block-clonotype-clustering'

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "@platforma-sdk/block-tools": "catalog:",
     "turbo": "catalog:",
     "typescript": "catalog:",
-    "shx": "catalog:"
+    "shx": "catalog:",
+    "lodash": "^4.17.21"
   },
   "//pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "@platforma-sdk/block-tools": "catalog:",
     "turbo": "catalog:",
     "typescript": "catalog:",
-    "shx": "catalog:",
-    "lodash": "^4.17.21"
+    "shx": "catalog:"
   },
   "//pnpm": {
     "overrides": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,3 +36,5 @@ catalog:
   'eslint': ^9.25.1
   '@changesets/cli': ^2.29.8
   'shx': ^0.4.0
+
+# Intentional edit to trigger the pnpm-workspace.yaml vs pnpm-lock.yaml drift gate.


### PR DESCRIPTION
## Purpose

Smoke-test the v4-beta CI **with the github-ci#166 cleanup applied** by triggering it from a consumer block.

- Original v4-beta change: [github-ci#164](https://github.com/milaboratory/github-ci/pull/164) (merged) — surfaces publish-time gates as PR-visible jobs.
- Cleanup under test: [github-ci#166](https://github.com/milaboratory/github-ci/pull/166) (draft) — splits preflight into two independent jobs and fixes third-party `@v4-beta` action pins back to `@v4`.

## What this PR does

1. Pins the reusable workflow call at the cleanup branch:
   `node-simple-pnpm.yaml@paulnewling/preflight-cleanup`
2. Modifies `pnpm-workspace.yaml` (adds a trailing comment) **without** touching `pnpm-lock.yaml`. Trips the lock-drift gate at `node-simple-pnpm.yaml:504`.
3. The block's catalog still has `@platforma-sdk/tengo-builder: 2.5.29` (latest is 3.0.2). Trips the require-latest gate too.

## Expected outcome (with #166 applied)

- `preflight (require-latest)` ❌ — tengo-builder is stale.
- `preflight (pnpm-lock-sync)` ❌ — workspace edited without lockfile update.
- Both checks should appear as **separate red rows** on the PR (not one collapsed row, and not skipped behind each other).
- `get run metadata` should now run cleanly (no more `actions/checkout@v4-beta` resolution error).

## Cleanup

Close this PR (do not merge) once observations are recorded. Branch can be deleted afterward.