### PR TITLE
[Draft] Migration to new column access

### DIFF
--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -1,19 +1,30 @@
 import type { GraphMakerState } from '@milaboratories/graph-maker';
 import strings from '@milaboratories/strings';
 import type {
+  ColumnUniversalId,
   PColumnIdAndSpec,
   PColumnSpec,
   PFrameHandle,
   PlDataTableStateV2,
   PlMultiSequenceAlignmentModel,
-  PlRef, SUniversalPColumnId,
+  PlRef,
+  PObjectId,
+  RelaxedColumnSelector,
+  SUniversalPColumnId,
 } from '@platforma-sdk/model';
 import {
   BlockModelV3,
+  Column,
+  ColumnsCollection,
   DataModelBuilder,
+  createGlobalPObjectId,
   createPFrameForGraphs,
   createPlDataTableStateV2,
   createPlDataTableV2,
+  extractPObjectId,
+  getColumnOptions,
+  isPlRef,
+  parseColumnId,
 } from '@platforma-sdk/model';
 export type * from '@milaboratories/helpers';
 
@@ -37,7 +48,6 @@ type OldArgs = {
   customBlockLabel: string;
   datasetRef?: PlRef;
   sequencesRef: SUniversalPColumnId[];
-  // Added sequenceType here for future use in algorithm selection in workflow
   sequenceType: 'aminoacid' | 'nucleotide';
   identity: number;
   similarityType: 'sequence-identity' | 'blosum40' | 'blosum50' | 'blosum62' | 'blosum80' | 'blosum90';
@@ -61,8 +71,8 @@ type OldUiState = {
 export type BlockData = {
   defaultBlockLabel: string;
   customBlockLabel: string;
-  datasetRef?: PlRef;
-  sequencesRef: SUniversalPColumnId[];
+  datasetRef?: ColumnUniversalId;
+  sequencesRef: ColumnUniversalId[];
   sequenceType: 'aminoacid' | 'nucleotide';
   identity: number;
   similarityType: 'sequence-identity' | 'blosum40' | 'blosum50' | 'blosum62' | 'blosum80' | 'blosum90';
@@ -112,6 +122,15 @@ const dataModel = new DataModelBuilder()
   .from<BlockData>('v1')
   .upgradeLegacy<OldArgs, OldUiState>(({ args, uiState }) => ({
     ...args,
+    // Legacy `datasetRef` was a `PlRef`. The new `BlockData` carries a
+    // `ColumnUniversalId` — for result-pool leaves that is
+    // `createGlobalPObjectId(blockId, name)`.
+    datasetRef: args.datasetRef
+      ? createGlobalPObjectId(args.datasetRef.blockId, args.datasetRef.name)
+      : undefined,
+    // `SUniversalPColumnId` is a type alias for `ColumnUniversalId` — same wire
+    // string. No conversion needed.
+    sequencesRef: args.sequencesRef as readonly ColumnUniversalId[] as ColumnUniversalId[],
     similarityType: (args.similarityType as string) === 'alignment-score' ? 'blosum62' : args.similarityType,
     tableState: uiState.tableState,
     graphStateBubble: uiState.graphStateBubble,
@@ -132,11 +151,11 @@ const dataModel = new DataModelBuilder()
     sequenceType: 'aminoacid',
     identity: 0.8,
     similarityType: defaultSimilarityType.value,
-    coverageThreshold: 0.8, // default value matching MMseqs2 default
-    coverageMode: 0, // default to coverage of query and target
-    highPrecision: false, // default to off, can be enabled manually in advanced settings
-    trimStart: 0, // default to no trimming from start
-    trimEnd: 0, // default to no trimming from end
+    coverageThreshold: 0.8,
+    coverageMode: 0,
+    highPrecision: false,
+    trimStart: 0,
+    trimEnd: 0,
     clusteringTool: 'easy-cluster',
     tableState: createPlDataTableStateV2(),
     graphStateBubble: {
@@ -167,6 +186,52 @@ const dataModel = new DataModelBuilder()
     },
   }));
 
+// Anchor candidates: (sampleId × clonotype-key-variant) pairs carrying
+// `pl7.app/isAnchor: 'true'`. Discovery runs host-side via
+// `ColumnsCollection.filter`; `getColumnOptions` renders distinct labels.
+const datasetSelectors: RelaxedColumnSelector[] = [
+  {
+    axes: [
+      { name: [{ type: 'exact', value: 'pl7.app/sampleId' }] },
+      { name: [{ type: 'exact', value: 'pl7.app/vdj/clonotypeKey' }] },
+    ],
+    annotations: { 'pl7.app/isAnchor': 'true' },
+  },
+  {
+    axes: [
+      { name: [{ type: 'exact', value: 'pl7.app/sampleId' }] },
+      { name: [{ type: 'exact', value: 'pl7.app/vdj/scClonotypeKey' }] },
+    ],
+    annotations: { 'pl7.app/isAnchor': 'true' },
+  },
+  {
+    axes: [
+      { name: [{ type: 'exact', value: 'pl7.app/sampleId' }] },
+      { name: [{ type: 'exact', value: 'pl7.app/variantKey' }] },
+    ],
+    annotations: { 'pl7.app/isAnchor': 'true' },
+  },
+];
+
+// Workflow-tengo's `addAnchor` / `addSingle` still consume the legacy
+// `PlRef` shape (object for anchors, canonical global-ref string for singles).
+// Walk the new `ColumnUniversalId` down to its leaf and assert it is a
+// global pool ref — anything else cannot be expressed in the current
+// workflow API and must surface as an error here, not as a tengo crash.
+function toGlobalLeaf(
+  id: ColumnUniversalId,
+  field: string,
+): { ref: PlRef; id: PObjectId } {
+  const leafId = extractPObjectId(id);
+  const leafKey = parseColumnId(leafId);
+  if (!isPlRef(leafKey)) {
+    throw new Error(
+      `${field}: expected a global pool reference, got ${JSON.stringify(leafKey)}`,
+    );
+  }
+  return { ref: leafKey, id: leafId };
+}
+
 export const platforma = BlockModelV3.create(dataModel)
 
   .args((data) => {
@@ -175,8 +240,8 @@ export const platforma = BlockModelV3.create(dataModel)
     return {
       defaultBlockLabel: data.defaultBlockLabel,
       customBlockLabel: data.customBlockLabel,
-      datasetRef: data.datasetRef,
-      sequencesRef: data.sequencesRef,
+      datasetRef: toGlobalLeaf(data.datasetRef, 'datasetRef').ref,
+      sequencesRef: data.sequencesRef.map((s) => toGlobalLeaf(s, 'sequencesRef').id),
       sequenceType: data.sequenceType,
       identity: data.identity,
       similarityType: data.similarityType,
@@ -191,87 +256,73 @@ export const platforma = BlockModelV3.create(dataModel)
     };
   })
 
-  .output('datasetOptions', (ctx) =>
-    ctx.resultPool.getOptions([{
-      axes: [
-        { name: 'pl7.app/sampleId' },
-        { name: 'pl7.app/vdj/clonotypeKey' },
-      ],
-      annotations: { 'pl7.app/isAnchor': 'true' },
-    }, {
-      axes: [
-        { name: 'pl7.app/sampleId' },
-        { name: 'pl7.app/vdj/scClonotypeKey' },
-      ],
-      annotations: { 'pl7.app/isAnchor': 'true' },
-    }, {
-      axes: [
-        { name: 'pl7.app/sampleId' },
-        { name: 'pl7.app/variantKey' },
-      ],
-      annotations: { 'pl7.app/isAnchor': 'true' },
-    }],
-    {
-      // suppress native label of the column (e.g. "Number of Reads") to show only the dataset label
-      label: { includeNativeLabel: false },
-    }),
+  .output('datasetOptions', () =>
+    getColumnOptions(
+      ColumnsCollection(['result_pool']).filter({ include: datasetSelectors }),
+      // suppress native label to show only the dataset label
+      { includeNativeLabel: false },
+    ),
   )
 
   .output('sequenceOptions', (ctx) => {
-    const ref = ctx.data.datasetRef;
-    if (ref === undefined) return undefined;
+    const datasetId = ctx.data.datasetRef;
+    if (datasetId === undefined) return undefined;
 
-    const axis1Name = ctx.resultPool.getPColumnSpecByRef(ref)?.axesSpec[1].name;
+    const anchorSpec = Column(datasetId)?.getSpec();
+    if (anchorSpec === undefined) return undefined;
+
+    const axis1Name = anchorSpec.axesSpec[1].name;
+    const axis1NameSelector: { type: 'exact'; value: string }[] = [
+      { type: 'exact', value: axis1Name },
+    ];
     const isPeptide = axis1Name === 'pl7.app/variantKey';
     const isSingleCell = axis1Name === 'pl7.app/vdj/scClonotypeKey';
 
-    const sequenceMatchers = [];
+    const sequenceMatchers: RelaxedColumnSelector[] = [];
 
     if (isPeptide) {
       sequenceMatchers.push({
-        axes: [{ anchor: 'main', idx: 1 }],
-        name: 'pl7.app/sequence',
+        axes: [{ name: axis1NameSelector }],
+        name: [{ type: 'exact', value: 'pl7.app/sequence' }],
         domain: {
           'pl7.app/feature': 'peptide',
           'pl7.app/alphabet': ctx.data.sequenceType,
         },
       });
     } else {
-      // const allowedFeatures = ['CDR1', 'CDR2', 'CDR3', 'FR1', 'FR2',
-      //   'FR3', 'FR4', 'FR4InFrame', 'VDJRegion', 'VDJRegionInFrame'];
-      // for (const feature of allowedFeatures) {
       if (isSingleCell) {
         sequenceMatchers.push({
-          axes: [{ anchor: 'main', idx: 1 }],
-          name: 'pl7.app/vdj/sequence',
+          axes: [{ name: axis1NameSelector }],
+          name: [{ type: 'exact', value: 'pl7.app/vdj/sequence' }],
           domain: {
-            // 'pl7.app/vdj/feature': feature,
             'pl7.app/vdj/scClonotypeChain/index': 'primary',
             'pl7.app/alphabet': ctx.data.sequenceType,
           },
         });
       } else {
         sequenceMatchers.push({
-          axes: [{ anchor: 'main', idx: 1 }],
-          name: 'pl7.app/vdj/sequence',
+          axes: [{ name: axis1NameSelector }],
+          name: [{ type: 'exact', value: 'pl7.app/vdj/sequence' }],
           domain: {
-            // 'pl7.app/vdj/feature': feature,
             'pl7.app/alphabet': ctx.data.sequenceType,
           },
         });
       }
 
-      // Check if any PColumns in the dataset have the name "pl7.app/vdj/scFv-sequence"
-      const scfvColumns = ctx.resultPool.getAnchoredPColumns(
-        { main: ref },
-        [{
-          name: 'pl7.app/vdj/scFv-sequence',
-        }],
-      );
-      if (scfvColumns && scfvColumns.length > 0) {
+      // Conditional scFv inclusion: probe the anchored discovery for any
+      // `pl7.app/vdj/scFv-sequence` columns; add the matcher only if present.
+      const scFvCount = ColumnsCollection(['result_pool'])
+        .discover({
+          anchors: { main: anchorSpec },
+          mode: 'enrichment',
+          include: [{ name: [{ type: 'exact', value: 'pl7.app/vdj/scFv-sequence' }] }],
+        })
+        .getColumns().length;
+
+      if (scFvCount > 0) {
         sequenceMatchers.push({
-          axes: [{ anchor: 'main', idx: 1 }],
-          name: 'pl7.app/vdj/scFv-sequence',
+          axes: [{ name: axis1NameSelector }],
+          name: [{ type: 'exact', value: 'pl7.app/vdj/scFv-sequence' }],
           domain: {
             'pl7.app/alphabet': ctx.data.sequenceType,
           },
@@ -279,37 +330,32 @@ export const platforma = BlockModelV3.create(dataModel)
       }
     }
 
-    return ctx.resultPool.getCanonicalOptions(
-      { main: ref },
-      sequenceMatchers,
-      { ignoreMissingDomains: true,
-        labelOps: {
-          includeNativeLabel: true,
-        },
-      });
+    return getColumnOptions(
+      ColumnsCollection(['result_pool']).discover({
+        anchors: { main: anchorSpec },
+        mode: 'enrichment',
+        include: sequenceMatchers,
+      }),
+      { includeNativeLabel: true },
+    );
   })
 
   .output('isSingleCell', (ctx) => {
     if (ctx.data.datasetRef === undefined) return undefined;
-
-    const spec = ctx.resultPool.getPColumnSpecByRef(ctx.data.datasetRef);
-    if (spec === undefined) {
-      return undefined;
-    }
-
+    const spec = Column(ctx.data.datasetRef)?.getSpec();
+    if (spec === undefined) return undefined;
     return spec.axesSpec[1].name === 'pl7.app/vdj/scClonotypeKey';
   })
 
   .output('modality', (ctx) => {
     const spec = ctx.data.datasetRef
-      ? ctx.resultPool.getPColumnSpecByRef(ctx.data.datasetRef)
+      ? Column(ctx.data.datasetRef)?.getSpec()
       : undefined;
     if (!spec) return undefined;
     for (const ax of spec.axesSpec) {
       if (ax.name === 'pl7.app/variantKey') return 'peptide';
       if (ax.name === 'pl7.app/vdj/clonotypeKey' || ax.name === 'pl7.app/vdj/scClonotypeKey') return 'antibody_tcr';
     }
-    // Fallback when the input is resolved but unrecognized.
     return 'antibody_tcr';
   }, { retentive: true })
 
@@ -339,22 +385,16 @@ export const platforma = BlockModelV3.create(dataModel)
       return createPFrameForGraphs(ctx, msaCols);
     }
 
-    const datasetRef = ctx.data.datasetRef;
-    if (datasetRef === undefined)
-      return undefined;
+    if (ctx.data.datasetRef === undefined) return undefined;
 
     const sequencesRef = ctx.data.sequencesRef;
-    if (sequencesRef.length === 0)
-      return undefined;
+    if (sequencesRef.length === 0) return undefined;
 
-    const seqCols = ctx.resultPool.getAnchoredPColumns(
-      { main: datasetRef },
-      sequencesRef.map((s) => JSON.parse(s) as never),
-    );
-    if (seqCols === undefined)
-      return undefined;
-
-    return createPFrameForGraphs(ctx, [...msaCols, ...seqCols]);
+    // `sequencesRef` ids may resolve to wrapped recipes (no PColumn form);
+    // hand them to `createPFrame` as ids and let the host materialize them.
+    // This skips the linker/label enrichment from `createPFrameForGraphs`,
+    // but msaCols already carry the joinable axis set the MSA viewer needs.
+    return ctx.createPFrame([...msaCols, ...sequencesRef]);
   })
 
   .output('linkerColumnId', (ctx) => {
@@ -370,13 +410,8 @@ export const platforma = BlockModelV3.create(dataModel)
   })
 
   .output('inputSpec', (ctx) => {
-    const anchor = ctx.data.datasetRef;
-    if (anchor === undefined)
-      return undefined;
-    const anchorSpec = ctx.resultPool.getPColumnSpecByRef(anchor);
-    if (anchorSpec === undefined)
-      return undefined;
-    return anchorSpec;
+    if (ctx.data.datasetRef === undefined) return undefined;
+    return Column(ctx.data.datasetRef)?.getSpec();
   })
 
   .outputWithStatus('clustersPf', (ctx): PFrameHandle | undefined => {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,17 @@
     "typescript": "catalog:",
     "shx": "catalog:"
   },
+  "pnpm": {
+    "overrides": {
+      "@milaboratories/uikit": "file:../platforma_1/lib/ui/uikit/package.tgz",
+      "@platforma-sdk/ui-vue": "file:../platforma_1/sdk/ui-vue/package.tgz",
+      "@platforma-sdk/model": "file:../platforma_1/sdk/model/package.tgz",
+      "@milaboratories/helpers": "file:../platforma_1/lib/util/helpers/package.tgz",
+      "@platforma-sdk/workflow-tengo": "file:../platforma_1/sdk/workflow-tengo/package.tgz",
+      "@milaboratories/pl-model-common": "file:../platforma_1/lib/model/common/package.tgz",
+      "@milaboratories/columns-collection-driver": "file:../platforma_1/lib/model/columns-collection-driver/package.tgz"
+    }
+  },
   "//pnpm": {
     "overrides": {
       "@milaboratories/pl-model-common": "file:/Users/poslavskysv/Projects/milab/platforma/platforma-sdk/lib/model/common/package.tgz",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,6 @@ catalogs:
     '@milaboratories/graph-maker':
       specifier: 1.4.2
       version: 1.4.2
-    '@milaboratories/helpers':
-      specifier: 1.14.2
-      version: 1.14.2
     '@milaboratories/multi-sequence-alignment':
       specifier: 1.47.12
       version: 1.47.12
@@ -39,9 +36,6 @@ catalogs:
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
-    '@platforma-sdk/model':
-      specifier: 1.77.0
-      version: 1.77.0
     '@platforma-sdk/package-builder':
       specifier: 3.12.0
       version: 3.12.0
@@ -51,12 +45,6 @@ catalogs:
     '@platforma-sdk/test':
       specifier: 1.77.1
       version: 1.77.1
-    '@platforma-sdk/ui-vue':
-      specifier: 1.77.0
-      version: 1.77.0
-    '@platforma-sdk/workflow-tengo':
-      specifier: 5.24.0
-      version: 5.24.0
     eslint:
       specifier: ^9.25.1
       version: 9.39.2
@@ -75,6 +63,15 @@ catalogs:
     vue:
       specifier: 3.5.24
       version: 3.5.24
+
+overrides:
+  '@milaboratories/uikit': file:../platforma_1/lib/ui/uikit/package.tgz
+  '@platforma-sdk/ui-vue': file:../platforma_1/sdk/ui-vue/package.tgz
+  '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
+  '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+  '@platforma-sdk/workflow-tengo': file:../platforma_1/sdk/workflow-tengo/package.tgz
+  '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
+  '@milaboratories/columns-collection-driver': file:../platforma_1/lib/model/columns-collection-driver/package.tgz
 
 importers:
 
@@ -116,16 +113,16 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.0)(@platforma-sdk/ui-vue@1.77.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.2(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/helpers':
-        specifier: 'catalog:'
-        version: 1.14.2
+        specifier: file:../../platforma_1/lib/util/helpers/package.tgz
+        version: file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
       '@platforma-sdk/model':
-        specifier: 'catalog:'
-        version: 1.77.0
+        specifier: file:../../platforma_1/sdk/model/package.tgz
+        version: file:../platforma_1/sdk/model/package.tgz
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
@@ -190,10 +187,10 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.0)(@platforma-sdk/ui-vue@1.77.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.2(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/multi-sequence-alignment':
         specifier: 'catalog:'
-        version: 1.47.12(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.0)(@platforma-sdk/ui-vue@1.77.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.47.12(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -201,11 +198,11 @@ importers:
         specifier: workspace:*
         version: link:../model
       '@platforma-sdk/model':
-        specifier: 'catalog:'
-        version: 1.77.0
+        specifier: file:../../platforma_1/sdk/model/package.tgz
+        version: file:../platforma_1/sdk/model/package.tgz
       '@platforma-sdk/ui-vue':
-        specifier: 'catalog:'
-        version: 1.77.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+        specifier: file:../../platforma_1/sdk/ui-vue/package.tgz
+        version: file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       vue:
         specifier: 'catalog:'
         version: 3.5.24(typescript@5.6.3)
@@ -238,8 +235,8 @@ importers:
         specifier: 'catalog:'
         version: 1.18.0
       '@platforma-sdk/workflow-tengo':
-        specifier: 'catalog:'
-        version: 5.24.0
+        specifier: file:../../platforma_1/sdk/workflow-tengo/package.tgz
+        version: file:../platforma_1/sdk/workflow-tengo/package.tgz
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
@@ -1003,22 +1000,24 @@ packages:
   '@milaboratories/biowasm-tools@2.0.3':
     resolution: {integrity: sha512-/X2PJ9VYmVKHZ12X7p2lgzEN+zqeycatVGdVA1ifsdBXE4bKNmCrWhUr4JRlpoB5wuj/J5chBbIi6N9y6Tk1aw==}
 
+  '@milaboratories/columns-collection-driver@file:../platforma_1/lib/model/columns-collection-driver/package.tgz':
+    resolution: {integrity: sha512-zPCm1ahEt0lSEZORv8sAGOKdNWKYcx6aQe8Dp+sf3jWvdbVss1Od970QA5gCe4xA5/QmdP6x/XWhsrgNlTH3rw==, tarball: file:../platforma_1/lib/model/columns-collection-driver/package.tgz}
+    version: 0.1.0
+
   '@milaboratories/computable@2.9.4':
     resolution: {integrity: sha512-MgUqC3/8cE41k01dV8yne+K0bUYA457XFP7b/Sf5QrxDp6zWqCpWuCgLlsUzJNzFFLXaODWnpAFUvOZyQcq4jg==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/graph-maker@1.4.2':
     resolution: {integrity: sha512-MIGMuVsT7QisCJNBCzXYqfBDQ5rjLpEbP8xeUoL23KKi/MjKeg/S2Srn/znWcTFtOFYdWOQjaPoaqcCEKvvICg==}
+    version: 1.4.2
     peerDependencies:
-      '@platforma-sdk/model': 1.73.3
-      '@platforma-sdk/ui-vue': 1.73.3
+      '@platforma-sdk/model': file:/Users/aleksandr/GIT/MILAB/platforma_1/sdk/model/package.tgz
+      '@platforma-sdk/ui-vue': file:/Users/aleksandr/GIT/MILAB/platforma_1/sdk/ui-vue/package.tgz
 
-  '@milaboratories/helpers@1.14.1':
-    resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
-    engines: {node: '>=22'}
-
-  '@milaboratories/helpers@1.14.2':
-    resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
+  '@milaboratories/helpers@file:../platforma_1/lib/util/helpers/package.tgz':
+    resolution: {integrity: sha512-yljZZSfq7iZlRsU8uG1hWLTUd5nWaazIcHlNH8nD8XP5qzgOVFFcvQCELHtwOFEuVCBb+t5idgL5NG8FTx701Q==, tarball: file:../platforma_1/lib/util/helpers/package.tgz}
+    version: 1.14.2
     engines: {node: '>=22'}
 
   '@milaboratories/miplots4@1.2.0':
@@ -1026,9 +1025,10 @@ packages:
 
   '@milaboratories/multi-sequence-alignment@1.47.12':
     resolution: {integrity: sha512-K0blTkxdxEi1ZWrTUAlSpqqBK9Kj2rZvs8SX+p56p9Z6bjg6CAZa3PYC7zCgggwZamP+S0rTziuha9W9cWZwUw==}
+    version: 1.47.12
     peerDependencies:
-      '@platforma-sdk/model': 1.73.3
-      '@platforma-sdk/ui-vue': 1.73.3
+      '@platforma-sdk/model': file:/Users/aleksandr/GIT/MILAB/platforma_1/sdk/model/package.tgz
+      '@platforma-sdk/ui-vue': file:/Users/aleksandr/GIT/MILAB/platforma_1/sdk/ui-vue/package.tgz
 
   '@milaboratories/pf-driver@1.4.11':
     resolution: {integrity: sha512-HBXt9vusZcMf0p4diAvZFoF+EXtxa67B4dKGIQJ/PMySYxfmW7OrZhgoXg/1zXVlucYvOp289ow0scaF+N0TlQ==}
@@ -1036,12 +1036,16 @@ packages:
 
   '@milaboratories/pf-plots@1.4.1':
     resolution: {integrity: sha512-qcJ/vzZLtxBi4mPGAvM1vQuBZfC2YYHLTTkJbsJUeWwfOjQg/YEuxoHkN58LXHnd6s0pcc7clAtpwdq0Y8JONQ==}
+    version: 1.4.1
     peerDependencies:
-      '@milaboratories/pl-model-common': 1.39.0
-      '@platforma-sdk/model': 1.73.3
+      '@milaboratories/pl-model-common': file:/Users/aleksandr/GIT/MILAB/platforma_1/lib/model/common/package.tgz
+      '@platforma-sdk/model': file:/Users/aleksandr/GIT/MILAB/platforma_1/sdk/model/package.tgz
 
   '@milaboratories/pf-spec-driver@1.3.16':
     resolution: {integrity: sha512-Podb1eNvcl1nQXG/LeT+ZiesSq17z4ixBNDk0Kj92RRYQ6IZDeDyCgUgrVH7/A/UZ/j/dyRzbjkOLBWmk3DDmQ==}
+
+  '@milaboratories/pf-spec-driver@1.3.17':
+    resolution: {integrity: sha512-ShmOxNr8ocgZJiOaSC1bD23L1+oqwiaPS5Hh8Bqa9FO1FP7DWPMWV0LtVuUr7ZRGLzivjh9ccQbMyK9QuP5pbg==}
 
   '@milaboratories/pframes-rs-node@1.1.35':
     resolution: {integrity: sha512-XGLRa29bOmpEUeHgpWNDYZDGDFvR7OfXqaodxaIAVtXnsrsjxzDz063z1sjRPDOx/Pz9T+5n4iRNuLyygwcQ5A==}
@@ -1055,9 +1059,10 @@ packages:
 
   '@milaboratories/pframes-rs-wasm@1.1.35':
     resolution: {integrity: sha512-wmnEujKa47y+CguYFbeYPjzYAsdhOQO/oNKIyCl0cG/RDwi3qtioKj6DMIBQgjC+/yLPuMsPkjXh7aaPn9cvpA==}
+    version: 1.1.35
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
-      '@milaboratories/pl-model-common': 1.36.0
+      '@milaboratories/pl-model-common': file:/Users/aleksandr/GIT/MILAB/platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.18.5
 
   '@milaboratories/pl-client@3.5.0':
@@ -1082,9 +1087,6 @@ packages:
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
-  '@milaboratories/pl-error-like@1.12.9':
-    resolution: {integrity: sha512-9qlfawLFO4qG656ayvVSRholhhwlfXUvKKllXpHadqbnf2zO2oCd+5J76bPaFXDz/A3T+1eokCnCX74JsqCYSw==}
-
   '@milaboratories/pl-errors@1.4.7':
     resolution: {integrity: sha512-YUP3KZc/m3N7+oPQTh2+2ZKjyQERRDVt1mXiQUPgZ0uMUHZDzK8q6INkvvDUGqQlBsAPLIxzO7PS2tW84ZpOBA==}
 
@@ -1101,11 +1103,9 @@ packages:
   '@milaboratories/pl-model-backend@1.3.1':
     resolution: {integrity: sha512-zDWTa/AqI2YSmD3FpQavWI9OnZzMRoNQS+E8YtdSadC9LkvetqY5YI9Uu/IAGrWVonlvjD6uA0PrPX5hACOxow==}
 
-  '@milaboratories/pl-model-common@1.36.0':
-    resolution: {integrity: sha512-BbFs3sTmy12ZKfTY6rFep0C5pfQoLvsjACN8EYaNIjXqOjQajt6velh4uGpB47+Uyp78k0cIWH4T04MIlixQrw==}
-
-  '@milaboratories/pl-model-common@1.42.0':
-    resolution: {integrity: sha512-ttX9OcQ9kgEhgyXZNkC7+vtsCaxjz+uNwmU8d2LlA56cpWgWV9WONi91w8nCRGFf9WboSgUVVaFj2XxiT9QHXQ==}
+  '@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz':
+    resolution: {integrity: sha512-EQ8F24fhIV8IhFKItjK+DELi6uEJSsJ4IRiRQUW8p1k1BIgjjuXOHadZCoyfWyzUHs3gmvw0CuMwR1UTljXuOw==, tarball: file:../platforma_1/lib/model/common/package.tgz}
+    version: 1.42.0
 
   '@milaboratories/pl-model-middle-layer@1.18.5':
     resolution: {integrity: sha512-eIYE77rBva0k2KWDUmKJBHnGcyi/Tnc5rhlwZVb8q3hS3L4Upf4Pk7/lBL4ZLxYVMZ3/Da0Wp3EKYspUagi9Zg==}
@@ -1151,8 +1151,9 @@ packages:
     resolution: {integrity: sha512-bQHcEAeJXyV95Gyk0yoRS5t3M71mFaNG+SsY2o+i4GDDeByUXBiF+T5A0elc/rCyLK6NNlOblou0DHBYOiW3pQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.14.10':
-    resolution: {integrity: sha512-Nssg54Pk5EViOY04qscmU9MlS4fk0B0paUcivuKQidmgHKXvJWsmNIp0XIbRMb8Uo8Kb0tGi9mqu3v7yghbVnA==}
+  '@milaboratories/uikit@file:../platforma_1/lib/ui/uikit/package.tgz':
+    resolution: {integrity: sha512-goWt6Xxe4gWrAVwLG4IBO+TSZ1PVNfgujY7lqSq9iCp230YmGZcs7RRZaeO18qKHRux2W0nd2jHPzFHHxPpYEw==, tarball: file:../platforma_1/lib/ui/uikit/package.tgz}
+    version: 2.14.11
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -1451,8 +1452,9 @@ packages:
       typescript: ~5.6.3
       typescript-eslint: ^8.17.0
 
-  '@platforma-sdk/model@1.77.0':
-    resolution: {integrity: sha512-XPpYMwRtsIXH91K2IBvzE8RzGJ/CXICQgDUBix6/ZjK+NNjBlGAqAiu6PiJZNTDF8xwd2TWQVSzorz8MxuJlnQ==}
+  '@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz':
+    resolution: {integrity: sha512-H7sd0OhOjlhk95aD4AW2OTjx8MoppRcmgiKgfOwz0LEj4MXfh/REWj9heRSSYsAYVj/n6VY/NszmgAJXXtlFqw==, tarball: file:../platforma_1/sdk/model/package.tgz}
+    version: 1.77.4
 
   '@platforma-sdk/package-builder@3.12.0':
     resolution: {integrity: sha512-bId52YqV5iLDAn9D9C3xaLD1bKyymGpHe2CDEZTqV+1yWCBh1RM6iH96JIXudVJdcmJaqwJWDw6X4WzStE6SCg==}
@@ -1466,11 +1468,13 @@ packages:
   '@platforma-sdk/test@1.77.1':
     resolution: {integrity: sha512-MEYH648sAYkMc0jMX9EVzaEhAhNf+37XRMIov+8S6myBVOH3YE297dB8DO77bFVZPcID0HTo44uJpAf6e1BvuQ==}
 
-  '@platforma-sdk/ui-vue@1.77.0':
-    resolution: {integrity: sha512-ih+oV/haDjLO9Qk8B+/JpPkKbhXyWDVsk58wHKUqR1l80mGslr9wwOUf+h99uhWTMa6jV1cmxHpqToV4obmmjw==}
+  '@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz':
+    resolution: {integrity: sha512-TGbfrODyn6wIq8ceX+LQKFRQBMhR/qrhwrAwFKv1QzWXE69MUZPYrOqV/X0neXQ4c6oJMAV0imnsEkq7fPVkVg==, tarball: file:../platforma_1/sdk/ui-vue/package.tgz}
+    version: 1.77.4
 
-  '@platforma-sdk/workflow-tengo@5.24.0':
-    resolution: {integrity: sha512-LFZbnHHU3yBulorph6867ZF0P8mtm0scEXQxplNJXxylMJp09uHSCKp/1JHhsMK7v8/iEY0Tph7RgVJXVSwmoA==}
+  '@platforma-sdk/workflow-tengo@file:../platforma_1/sdk/workflow-tengo/package.tgz':
+    resolution: {integrity: sha512-mgHI8DZsHpdwNKbE7wXGnyWkpB9t9SmisknFnqVsdWEWVJbNT71LCYD86cnbg9HhRgH2Gbw4k37ivd0yU4Jyeg==, tarball: file:../platforma_1/sdk/workflow-tengo/package.tgz}
+    version: 5.25.0
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -6211,9 +6215,6 @@ packages:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
 
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
-
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -7399,6 +7400,11 @@ snapshots:
 
   '@milaboratories/biowasm-tools@2.0.3': {}
 
+  '@milaboratories/columns-collection-driver@file:../platforma_1/lib/model/columns-collection-driver/package.tgz':
+    dependencies:
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
+
   '@milaboratories/computable@2.9.4':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.10
@@ -7406,14 +7412,14 @@ snapshots:
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
-  '@milaboratories/graph-maker@1.4.2(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.0)(@platforma-sdk/ui-vue@1.77.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/graph-maker@1.4.2(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.5
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/miplots4': 1.2.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.1(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.0)
-      '@platforma-sdk/model': 1.77.0
-      '@platforma-sdk/ui-vue': 1.77.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/pf-plots': 1.4.1(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)
+      '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
+      '@platforma-sdk/ui-vue': file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@types/d3-hierarchy': 3.1.7
       '@types/d3-scale': 4.0.9
       '@vueuse/core': 13.4.0(vue@3.5.25(typescript@5.6.3))
@@ -7430,9 +7436,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@milaboratories/helpers@1.14.1': {}
-
-  '@milaboratories/helpers@1.14.2': {}
+  '@milaboratories/helpers@file:../platforma_1/lib/util/helpers/package.tgz': {}
 
   '@milaboratories/miplots4@1.2.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
     dependencies:
@@ -7472,13 +7476,13 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/multi-sequence-alignment@1.47.12(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.0)(@platforma-sdk/ui-vue@1.77.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/multi-sequence-alignment@1.47.12(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)(@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@milaboratories/biowasm-tools': 2.0.3
       '@milaboratories/miplots4': 1.2.0(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.1(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.0)
-      '@platforma-sdk/model': 1.77.0
-      '@platforma-sdk/ui-vue': 1.77.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/pf-plots': 1.4.1(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)
+      '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
+      '@platforma-sdk/ui-vue': file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       vue: 3.5.25(typescript@5.6.3)
     transitivePeerDependencies:
       - '@milaboratories/pl-model-common'
@@ -7490,10 +7494,10 @@ snapshots:
 
   '@milaboratories/pf-driver@1.4.11(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/pframes-rs-node': 1.1.35
-      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.19.4)
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@milaboratories/pl-model-middle-layer@1.19.4)
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.19.4
       '@milaboratories/ts-helpers': 1.8.2
       es-toolkit: 1.39.10
@@ -7503,20 +7507,30 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-plots@1.4.1(@milaboratories/pl-model-common@1.42.0)(@platforma-sdk/model@1.77.0)':
+  '@milaboratories/pf-plots@1.4.1(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.42.0
-      '@platforma-sdk/model': 1.77.0
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
+      '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
       canonicalize: 2.1.0
       lodash: 4.17.21
 
   '@milaboratories/pf-spec-driver@1.3.16(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.19.4)
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@milaboratories/pl-model-middle-layer@1.19.4)
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.19.4
+      '@noble/hashes': 2.0.1
+    transitivePeerDependencies:
+      - '@bytecodealliance/preview2-shim'
+
+  '@milaboratories/pf-spec-driver@1.3.17(@bytecodealliance/preview2-shim@0.17.8)':
+    dependencies:
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@milaboratories/pl-model-middle-layer@1.20.0)
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
+      '@milaboratories/pl-model-middle-layer': 1.20.0
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
@@ -7524,9 +7538,9 @@ snapshots:
   '@milaboratories/pframes-rs-node@1.1.35':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
-      '@milaboratories/helpers': 1.14.1
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/pframes-rs-serv': 1.1.35
-      '@milaboratories/pl-model-common': 1.36.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
@@ -7534,26 +7548,33 @@ snapshots:
 
   '@milaboratories/pframes-rs-serv@1.1.35':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.36.0
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.18.5
       commander: 14.0.3
       selfsigned: 5.5.0
 
   '@milaboratories/pframes-rs-wasip2@1.1.35': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.19.4)':
+  '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@milaboratories/pl-model-middle-layer@1.19.4)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
       '@milaboratories/pframes-rs-wasip2': 1.1.35
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.19.4
+
+  '@milaboratories/pframes-rs-wasm@1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@milaboratories/pl-model-middle-layer@1.20.0)':
+    dependencies:
+      '@bytecodealliance/preview2-shim': 0.17.8
+      '@milaboratories/pframes-rs-wasip2': 1.1.35
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
+      '@milaboratories/pl-model-middle-layer': 1.20.0
 
   '@milaboratories/pl-client@3.5.0':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/ts-helpers': 1.8.2
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
@@ -7571,7 +7592,7 @@ snapshots:
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/ts-helpers': 1.8.2
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
@@ -7595,7 +7616,7 @@ snapshots:
     dependencies:
       '@milaboratories/pl-config': 1.8.1
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/ts-helpers': 1.8.2
       decompress: 4.2.1
       ssh2: 1.16.0
@@ -7609,9 +7630,9 @@ snapshots:
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/computable': 2.9.4
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/pl-client': 3.5.0
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-tree': 1.11.0
       '@milaboratories/ts-helpers': 1.8.2
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
@@ -7632,11 +7653,6 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.25.76
 
-  '@milaboratories/pl-error-like@1.12.9':
-    dependencies:
-      json-stringify-safe: 5.0.1
-      zod: 3.23.8
-
   '@milaboratories/pl-errors@1.4.7':
     dependencies:
       '@milaboratories/pl-client': 3.5.0
@@ -7650,25 +7666,25 @@ snapshots:
   '@milaboratories/pl-middle-layer@1.60.3(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/computable': 2.9.4
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/pf-driver': 1.4.11(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pf-spec-driver': 1.3.16(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pframes-rs-node': 1.1.35
-      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.42.0)(@milaboratories/pl-model-middle-layer@1.19.4)
+      '@milaboratories/pframes-rs-wasm': 1.1.35(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz)(@milaboratories/pl-model-middle-layer@1.19.4)
       '@milaboratories/pl-client': 3.5.0
       '@milaboratories/pl-deployments': 2.17.18
       '@milaboratories/pl-drivers': 1.14.7
       '@milaboratories/pl-errors': 1.4.7
       '@milaboratories/pl-http': 1.2.4
       '@milaboratories/pl-model-backend': 1.2.29
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.19.4
       '@milaboratories/pl-tree': 1.11.0
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.2
       '@platforma-sdk/block-tools': 2.7.25
-      '@platforma-sdk/model': 1.77.0
-      '@platforma-sdk/workflow-tengo': 5.24.0
+      '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
+      '@platforma-sdk/workflow-tengo': file:../platforma_1/sdk/workflow-tengo/package.tgz
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.39.10
@@ -7696,40 +7712,34 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.36.0':
+  '@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-error-like': 1.12.9
-      canonicalize: 2.1.0
-      zod: 3.25.76
-
-  '@milaboratories/pl-model-common@1.42.0':
-    dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
+      es-toolkit: 1.39.10
       zod: 3.25.76
 
   '@milaboratories/pl-model-middle-layer@1.18.5':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.36.0
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76
 
   '@milaboratories/pl-model-middle-layer@1.19.4':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76
 
   '@milaboratories/pl-model-middle-layer@1.20.0':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76
@@ -7765,7 +7775,7 @@ snapshots:
       oxfmt: 0.35.0
       oxlint: 1.43.0
       rolldown: 1.0.0-rc.17
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.5.2)(rollup@4.53.5)
       typescript: 5.9.3
@@ -7805,7 +7815,7 @@ snapshots:
       oxfmt: 0.35.0
       oxlint: 1.43.0
       rolldown: 1.0.0-rc.17
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.5.2)(rollup@4.53.5)
       typescript: 5.9.3
@@ -7845,14 +7855,14 @@ snapshots:
 
   '@milaboratories/ts-helpers@1.8.2':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.14.10(typescript@5.6.3)':
+  '@milaboratories/uikit@file:../platforma_1/lib/ui/uikit/package.tgz(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@platforma-sdk/model': 1.77.0
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
+      '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
       '@types/d3-array': 3.2.1
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -8125,7 +8135,7 @@ snapshots:
 
   '@platforma-open/milaboratories.software-ptabler.schema@1.15.9':
     dependencies:
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
 
   '@platforma-open/milaboratories.software-ptabler@1.16.1': {}
 
@@ -8152,7 +8162,7 @@ snapshots:
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.19.4
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.2
@@ -8174,7 +8184,7 @@ snapshots:
       '@aws-sdk/client-s3': 3.859.0
       '@milaboratories/pl-http': 1.2.4
       '@milaboratories/pl-model-backend': 1.3.1
-      '@milaboratories/pl-model-common': 1.42.0
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
       '@milaboratories/pl-model-middle-layer': 1.20.0
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.2
@@ -8206,16 +8216,17 @@ snapshots:
       typescript: 5.6.3
       typescript-eslint: 8.24.0(eslint@9.39.2)(typescript@5.6.3)
 
-  '@platforma-sdk/model@1.77.0':
+  '@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': file:../platforma_1/lib/util/helpers/package.tgz
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/pl-model-middle-layer': 1.19.4
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
+      '@milaboratories/pl-model-middle-layer': 1.20.0
       '@milaboratories/ptabler-expression-js': 1.2.25
       canonicalize: 2.1.0
       es-toolkit: 1.39.10
       fast-json-patch: 3.1.1
+      lru-cache: 11.2.2
       utility-types: 3.11.0
       zod: 3.25.76
 
@@ -8250,7 +8261,7 @@ snapshots:
       '@milaboratories/pl-client': 3.5.0
       '@milaboratories/pl-middle-layer': 1.60.3(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pl-tree': 1.11.0
-      '@platforma-sdk/model': 1.77.0
+      '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
       '@vitest/coverage-istanbul': 4.1.5(vitest@4.1.5)
       vitest: 4.1.5(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.5(vitest@4.0.8(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1)))(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
     transitivePeerDependencies:
@@ -8271,12 +8282,13 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.77.0(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
+  '@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.3.16(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-model-common': 1.42.0
-      '@milaboratories/uikit': 2.14.10(typescript@5.6.3)
-      '@platforma-sdk/model': 1.77.0
+      '@milaboratories/columns-collection-driver': file:../platforma_1/lib/model/columns-collection-driver/package.tgz
+      '@milaboratories/pf-spec-driver': 1.3.17(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
+      '@milaboratories/uikit': file:../platforma_1/lib/ui/uikit/package.tgz(typescript@5.6.3)
+      '@platforma-sdk/model': file:../platforma_1/sdk/model/package.tgz
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.0
@@ -8307,8 +8319,9 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@5.24.0':
+  '@platforma-sdk/workflow-tengo@file:../platforma_1/sdk/workflow-tengo/package.tgz':
     dependencies:
+      '@milaboratories/pframes-rs-wasip2': 1.1.35
       '@milaboratories/software-pframes-conv': 2.2.9
       '@platforma-open/milaboratories.software-ptabler': 1.16.1
       '@platforma-open/milaboratories.software-ptexter': 1.2.2
@@ -13065,7 +13078,7 @@ snapshots:
     dependencies:
       glob: 10.4.5
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
@@ -13768,8 +13781,6 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
-
-  zod@3.23.8: {}
 
   zod@3.25.76: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: 3.12.0
       version: 3.12.0
     '@platforma-sdk/tengo-builder':
-      specifier: 2.5.29
-      version: 2.5.29
+      specifier: 3.0.0
+      version: 3.0.0
     '@platforma-sdk/test':
       specifier: 1.77.1
       version: 1.77.1
@@ -240,7 +240,7 @@ importers:
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 2.5.29
+        version: 3.0.0
 
 packages:
 
@@ -1001,7 +1001,7 @@ packages:
     resolution: {integrity: sha512-/X2PJ9VYmVKHZ12X7p2lgzEN+zqeycatVGdVA1ifsdBXE4bKNmCrWhUr4JRlpoB5wuj/J5chBbIi6N9y6Tk1aw==}
 
   '@milaboratories/columns-collection-driver@file:../platforma_1/lib/model/columns-collection-driver/package.tgz':
-    resolution: {integrity: sha512-zPCm1ahEt0lSEZORv8sAGOKdNWKYcx6aQe8Dp+sf3jWvdbVss1Od970QA5gCe4xA5/QmdP6x/XWhsrgNlTH3rw==, tarball: file:../platforma_1/lib/model/columns-collection-driver/package.tgz}
+    resolution: {integrity: sha512-oc0vn5f0ZD9D5BliAdB/lGKDkDmiHbgnP0XkYaZcToZ4ay9z79Gi7rcSN4eE2XE9nRQKk+jyh15h5tU5UiKujg==, tarball: file:../platforma_1/lib/model/columns-collection-driver/package.tgz}
     version: 0.1.0
 
   '@milaboratories/computable@2.9.4':
@@ -1069,6 +1069,10 @@ packages:
     resolution: {integrity: sha512-eVDnXExhKB4DYzqkWD49MYyi6AyBxWyG8WoDMFrB23FjyHgMTR7rSoep0iUsWEoLLGnwq4Qd8l89/hBYpAVg0A==}
     engines: {node: '>=22.19.0'}
 
+  '@milaboratories/pl-client@3.7.0':
+    resolution: {integrity: sha512-/mBCy4IfS/sR8allgq3XfBBBxjEY0lcwbN8xxS2U+SWKaWVkgQZgQFRek8RmWAST6Qsnl60TvY6RpeAq2JBTCw==}
+    engines: {node: '>=22.19.0'}
+
   '@milaboratories/pl-client@3.8.0':
     resolution: {integrity: sha512-ADUFHvwtGDC/sOYd4btCw2GdR58gq3+Nm9yV3UUYhmH5dv3J/1tXsxJH15mv1mT9YvK0IS4vMw0eDteeQUmaiQ==}
     engines: {node: '>=22.19.0'}
@@ -1100,11 +1104,14 @@ packages:
   '@milaboratories/pl-model-backend@1.2.29':
     resolution: {integrity: sha512-0jL+k6z6MJha0XMFXq/e814THyvNZZNeBB6zcLYtiWKVYRCKp/iK43xOFCzGAgT1uQVz4AdhKsqgqQv5B9deBw==}
 
+  '@milaboratories/pl-model-backend@1.3.0':
+    resolution: {integrity: sha512-fY0FobfDtE+ZN6D6yrPgNo/28pwjQt/KeYeJTcfFVcDAEv8kltxfb7hhE36nl7Af27msodvZVtEmDNqWP/xKuQ==}
+
   '@milaboratories/pl-model-backend@1.3.1':
     resolution: {integrity: sha512-zDWTa/AqI2YSmD3FpQavWI9OnZzMRoNQS+E8YtdSadC9LkvetqY5YI9Uu/IAGrWVonlvjD6uA0PrPX5hACOxow==}
 
   '@milaboratories/pl-model-common@file:../platforma_1/lib/model/common/package.tgz':
-    resolution: {integrity: sha512-EQ8F24fhIV8IhFKItjK+DELi6uEJSsJ4IRiRQUW8p1k1BIgjjuXOHadZCoyfWyzUHs3gmvw0CuMwR1UTljXuOw==, tarball: file:../platforma_1/lib/model/common/package.tgz}
+    resolution: {integrity: sha512-aton7jR+IBtt1FndvwAI5czXNUwKG1jyMKQqRd8Jomn4V0RclhaG5tREJtjep9EZkxiXVRCU0q9qM05ZuJbgog==, tarball: file:../platforma_1/lib/model/common/package.tgz}
     version: 1.42.0
 
   '@milaboratories/pl-model-middle-layer@1.18.5':
@@ -1152,7 +1159,7 @@ packages:
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/uikit@file:../platforma_1/lib/ui/uikit/package.tgz':
-    resolution: {integrity: sha512-goWt6Xxe4gWrAVwLG4IBO+TSZ1PVNfgujY7lqSq9iCp230YmGZcs7RRZaeO18qKHRux2W0nd2jHPzFHHxPpYEw==, tarball: file:../platforma_1/lib/ui/uikit/package.tgz}
+    resolution: {integrity: sha512-wPmQifIQRmbJx+i6GgoCNuKLGJEe2RGHb7hD6lmtBTCENrxAFE5AnnMBijnW+0loy3r/KRvEmVb5J8dgb5MRjg==, tarball: file:../platforma_1/lib/ui/uikit/package.tgz}
     version: 2.14.11
 
   '@napi-rs/wasm-runtime@1.1.4':
@@ -1453,15 +1460,15 @@ packages:
       typescript-eslint: ^8.17.0
 
   '@platforma-sdk/model@file:../platforma_1/sdk/model/package.tgz':
-    resolution: {integrity: sha512-H7sd0OhOjlhk95aD4AW2OTjx8MoppRcmgiKgfOwz0LEj4MXfh/REWj9heRSSYsAYVj/n6VY/NszmgAJXXtlFqw==, tarball: file:../platforma_1/sdk/model/package.tgz}
+    resolution: {integrity: sha512-eVfpfNde6ozAUcRz37fE7rpZBEFGIOdmjGk2wALxaphYFxA/IL6c+nYK4Ihxf/bbNVAaQD9amlBFJWP1cLaLEA==, tarball: file:../platforma_1/sdk/model/package.tgz}
     version: 1.77.4
 
   '@platforma-sdk/package-builder@3.12.0':
     resolution: {integrity: sha512-bId52YqV5iLDAn9D9C3xaLD1bKyymGpHe2CDEZTqV+1yWCBh1RM6iH96JIXudVJdcmJaqwJWDw6X4WzStE6SCg==}
     hasBin: true
 
-  '@platforma-sdk/tengo-builder@2.5.29':
-    resolution: {integrity: sha512-iurwyuFCq1DynPuoud182Ebdrk8dhSjLddkOSvPQb1QZ+HVU/CcEfIx0SgZ+qOLstHQ1lB2YeHv7GCaMHsjI9A==}
+  '@platforma-sdk/tengo-builder@3.0.0':
+    resolution: {integrity: sha512-HfKoCZLHKwfdgwXqpYcp/gBxrFix5C8BJfkwSybZ3XNvFMcl+gvvwhFfmOwwY+TEcbiqNx21Z1GPFD5prY3g/A==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -1469,11 +1476,11 @@ packages:
     resolution: {integrity: sha512-MEYH648sAYkMc0jMX9EVzaEhAhNf+37XRMIov+8S6myBVOH3YE297dB8DO77bFVZPcID0HTo44uJpAf6e1BvuQ==}
 
   '@platforma-sdk/ui-vue@file:../platforma_1/sdk/ui-vue/package.tgz':
-    resolution: {integrity: sha512-TGbfrODyn6wIq8ceX+LQKFRQBMhR/qrhwrAwFKv1QzWXE69MUZPYrOqV/X0neXQ4c6oJMAV0imnsEkq7fPVkVg==, tarball: file:../platforma_1/sdk/ui-vue/package.tgz}
+    resolution: {integrity: sha512-GL0ySVx7DmIdXjy/Z2NSmDQXRac/OomJRoP1prtNZw50xiiO8ThEwPDh9wmb0ve40hMw5C7gAsQrOQfyjlOniQ==, tarball: file:../platforma_1/sdk/ui-vue/package.tgz}
     version: 1.77.4
 
   '@platforma-sdk/workflow-tengo@file:../platforma_1/sdk/workflow-tengo/package.tgz':
-    resolution: {integrity: sha512-mgHI8DZsHpdwNKbE7wXGnyWkpB9t9SmisknFnqVsdWEWVJbNT71LCYD86cnbg9HhRgH2Gbw4k37ivd0yU4Jyeg==, tarball: file:../platforma_1/sdk/workflow-tengo/package.tgz}
+    resolution: {integrity: sha512-/oP64hXfTO1bBUkdSG8VbfKYq06gg5QfiAYlJuRF0gL5yJTMbuZUiGaS11QI/rfHSKhRnDA04j2Qh6/gH9D99w==, tarball: file:../platforma_1/sdk/workflow-tengo/package.tgz}
     version: 5.25.0
 
   '@protobuf-ts/grpc-transport@2.11.1':
@@ -7588,6 +7595,24 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.1
 
+  '@milaboratories/pl-client@3.7.0':
+    dependencies:
+      '@grpc/grpc-js': 1.13.4
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-common': file:../platforma_1/lib/model/common/package.tgz
+      '@milaboratories/ts-helpers': 1.8.2
+      '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+      canonicalize: 2.1.0
+      denque: 2.1.0
+      long: 5.3.2
+      lru-cache: 11.2.2
+      openapi-fetch: 0.15.0
+      undici: 7.16.0
+      utility-types: 3.11.0
+      yaml: 2.8.1
+
   '@milaboratories/pl-client@3.8.0':
     dependencies:
       '@grpc/grpc-js': 1.13.4
@@ -7703,6 +7728,12 @@ snapshots:
   '@milaboratories/pl-model-backend@1.2.29':
     dependencies:
       '@milaboratories/pl-client': 3.5.0
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-backend@1.3.0':
+    dependencies:
+      '@milaboratories/pl-client': 3.7.0
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -8246,9 +8277,9 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@platforma-sdk/tengo-builder@2.5.29':
+  '@platforma-sdk/tengo-builder@3.0.0':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.2.29
+      '@milaboratories/pl-model-backend': 1.3.0
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
       '@milaboratories/ts-helpers': 1.8.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ catalog:
   '@platforma-sdk/workflow-tengo': 5.24.0
   '@platforma-sdk/model': 1.77.0
   '@platforma-sdk/ui-vue': 1.77.0
-  '@platforma-sdk/tengo-builder': 2.5.29
+  '@platforma-sdk/tengo-builder': 3.0.0
   '@platforma-sdk/package-builder': 3.12.0
   '@platforma-sdk/block-tools': 2.8.1
   '@platforma-sdk/eslint-config': 1.2.0

--- a/ui/src/app.ts
+++ b/ui/src/app.ts
@@ -31,7 +31,7 @@ function syncDefaultBlockLabel(model: AppModel) {
     const sequenceLabels = model.data.sequencesRef
       .map((r) => {
         const label = model.outputs.sequenceOptions
-          ?.find((o) => o.value === r)
+          ?.find((o) => o.id === r)
           ?.label;
         return label?.replace('InFrame', '') ?? '';
       });

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -2,7 +2,7 @@
 import { PlMultiSequenceAlignment } from '@milaboratories/multi-sequence-alignment';
 import strings from '@milaboratories/strings';
 import { clusteringToolOptions, similarityTypeOptions } from '@platforma-open/milaboratories.clonotype-clustering.model';
-import type { AxisId, PColumnIdAndSpec, PlRef, PlSelectionModel, PTableKey, SUniversalPColumnId } from '@platforma-sdk/model';
+import type { AxisId, ColumnUniversalId, PColumnIdAndSpec, PlSelectionModel, PTableKey } from '@platforma-sdk/model';
 import {
   listToOptions,
   PlAccordionSection,
@@ -58,9 +58,19 @@ const onRowDoubleClicked = reactive((key?: PTableKey) => {
   multipleSequenceAlignmentOpen.value = true;
 });
 
-function setInput(inputRef?: PlRef) {
+function setInput(inputRef?: ColumnUniversalId) {
   app.model.data.datasetRef = inputRef;
 }
+
+// `getColumnOptions` returns `{ id, label }`; `PlDropdownRef` / `PlDropdownMulti`
+// expect `{ value, label }`. Wrap in a computed rather than touching every
+// model output.
+const datasetOptions = computed(() =>
+  app.model.outputs.datasetOptions?.map((o) => ({ value: o.id, label: o.label })),
+);
+const sequenceOptions = computed(() =>
+  app.model.outputs.sequenceOptions?.map((o) => ({ value: o.id, label: o.label })),
+);
 
 const tableSettings = usePlDataTableSettingsV2({
   model: () => app.model.outputs.clustersTable,
@@ -101,9 +111,9 @@ const hasCDR3Sequences = computed(() => {
     return false;
   }
 
-  const sequenceOptions = app.model.outputs.sequenceOptions;
+  const opts = app.model.outputs.sequenceOptions;
   return app.model.data.sequencesRef.some((selectedId) => {
-    const option = sequenceOptions.find((opt) => opt.value === selectedId);
+    const option = opts.find((opt) => opt.id === selectedId);
     if (!option) return false;
 
     // Check if the column name contains CDR3 (case insensitive)
@@ -119,16 +129,16 @@ const hasCDR3Sequences = computed(() => {
 // every nested property a new reference. A watcher would fire on that
 // replacement and clobber the user's explicit BLOSUM choice on app reopen
 // or any concurrent write.
-function onSequencesRefChange(sequencesRef: SUniversalPColumnId[]) {
+function onSequencesRefChange(sequencesRef: ColumnUniversalId[]) {
   app.model.data.sequencesRef = sequencesRef;
 
   if (app.model.data.similarityType === 'sequence-identity') return;
 
-  const sequenceOptions = app.model.outputs.sequenceOptions;
-  if (!sequencesRef?.length || !sequenceOptions) return;
+  const opts = app.model.outputs.sequenceOptions;
+  if (!sequencesRef?.length || !opts) return;
 
   const allFramework = sequencesRef.every((selectedId) => {
-    const option = sequenceOptions.find((opt) => opt.value === selectedId);
+    const option = opts.find((opt) => opt.id === selectedId);
     if (!option) return false;
     const label = option.label?.toLowerCase() || '';
     return label.includes('fr') && !label.includes('cdr');
@@ -187,7 +197,7 @@ const clusterAxis = computed<AxisId>(() => {
       <template #title>{{ strings.titles.settings }}</template>
       <PlDropdownRef
         v-model="app.model.data.datasetRef"
-        :options="app.model.outputs.datasetOptions"
+        :options="datasetOptions"
         :label="strings.titles.dataset"
         clearable
         required
@@ -201,7 +211,7 @@ const clusterAxis = computed<AxisId>(() => {
       />
       <PlDropdownMulti
         :model-value="app.model.data.sequencesRef"
-        :options="app.model.outputs.sequenceOptions"
+        :options="sequenceOptions"
         label="Sequence Columns to Cluster"
         required
         :disabled="app.model.data.datasetRef === undefined"


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR migrates the block model from the legacy `PlRef`/`SUniversalPColumnId` column-access API to the new `ColumnUniversalId` + `ColumnsCollection`/`Column` API, updating both `BlockData` types and all output computations. A `toGlobalLeaf()` bridge function preserves backward compatibility with the workflow-tengo layer while a `upgradeLegacy` handler handles on-disk data migration.

- **Model (`model/src/index.ts`)**: Replaces `ctx.resultPool.getOptions`, `getPColumnSpecByRef`, and `getAnchoredPColumns` calls with `ColumnsCollection`, `Column`, and `getColumnOptions`; adds `toGlobalLeaf()` to convert new ids back to the `PlRef` shape required by the Tengo workflow.
- **UI (`MainPage.vue`, `app.ts`)**: Wraps the new `{ id, label }` option shape into `{ value, label }` via computed properties so existing dropdown components continue to work without modification.
- **Dependency overrides** (`package.json`, `pnpm-lock.yaml`): Adds a live `pnpm.overrides` block pointing to local `file:../platforma_1/...` tarballs and regenerates the lock file from them — these machine-local paths must be removed before this can be installed on CI or by other contributors.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge as-is: the committed pnpm overrides pointing to local file: paths will cause install failures on CI and other developer machines.

The core model migration is well-structured and the legacy upgrade path is handled carefully. However, the lock file and package.json have been regenerated against local filesystem tarballs that don't exist outside the author's machine, which breaks the entire install and build pipeline for everyone else.

package.json and pnpm-lock.yaml — the live pnpm.overrides block with local file: paths must be removed and the lock file regenerated against published registry versions.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| model/src/index.ts | Migrates BlockData from PlRef/SUniversalPColumnId to ColumnUniversalId, adds ColumnsCollection-based discovery, and introduces toGlobalLeaf() for legacy workflow compatibility. Logic is sound but axesSpec[1] is accessed without a bounds check. |
| package.json | Adds a live pnpm.overrides block with local-filesystem file: paths that will break pnpm install on any machine other than the author's; these should be moved to the existing //pnpm commented block or removed before merge. |
| pnpm-lock.yaml | Regenerated with local file: tarball paths throughout; will fail to install on CI or other machines. Must be regenerated against published package versions after removing the local overrides. |
| pnpm-workspace.yaml | Catalog version declarations are stale (e.g., workflow-tengo at 5.24.0, model at 1.77.0) while the lock file resolves them to newer local tarballs; needs version bumps after overrides are removed. |
| ui/src/app.ts | No functional changes; only adapts to new sequenceOptions shape (id/label instead of value/label) via the computed wrappers added in MainPage.vue. |
| ui/src/pages/MainPage.vue | Adapts dropdowns to new ColumnUniversalId option shape with computed wrappers; dead sequencesRef === undefined condition should be sequencesRef.length === 0. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BlockData.datasetRef ColumnUniversalId] --> B[Column id .getSpec]
    B --> C{axesSpec 1 .name}
    C -->|variantKey| D[isPeptide = true]
    C -->|scClonotypeKey| E[isSingleCell = true]
    C -->|clonotypeKey| F[standard VDJ]
    D --> G[sequenceMatchers pl7.app/sequence]
    E --> H[sequenceMatchers pl7.app/vdj/sequence + scClonotypeChain primary]
    F --> I[sequenceMatchers pl7.app/vdj/sequence]
    F --> J[ColumnsCollection.discover scFv probe]
    J -->|scFvCount > 0| K[Add scFv matcher]
    G --> L[getColumnOptions sequenceOptions output]
    H --> L
    I --> L
    K --> L
    A --> M[toGlobalLeaf extractPObjectId + parseColumnId]
    M -->|isPlRef| N[args.datasetRef PlRef for Tengo workflow]
    M -->|not PlRef| O[throw Error]
    P[BlockData.sequencesRef ColumnUniversalId array] --> Q[map toGlobalLeaf args.sequencesRef PObjectId array]
    Q --> R[ctx.createPFrame msaPf output]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `pnpm-workspace.yaml`, line 12-16 ([link](https://github.com/platforma-open/clonotype-clustering/blob/a90ac7a141f703b724ddcd3ddf5fca1e56f39403/pnpm-workspace.yaml#L12-L16)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Catalog version entries are stale relative to the installed local overrides**

   The catalog still declares `@platforma-sdk/workflow-tengo: 5.24.0`, `@platforma-sdk/model: 1.77.0`, and `@platforma-sdk/ui-vue: 1.77.0`, but `pnpm-lock.yaml` resolves all of these to local tarballs that are actually version `5.25.0`, `1.77.4`, and `1.77.4` respectively. After the local overrides are removed, the catalog entries should be bumped to the intended release versions so the lock file matches what the workspace declares.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: pnpm-workspace.yaml
   Line: 12-16

   Comment:
   **Catalog version entries are stale relative to the installed local overrides**

   The catalog still declares `@platforma-sdk/workflow-tengo: 5.24.0`, `@platforma-sdk/model: 1.77.0`, and `@platforma-sdk/ui-vue: 1.77.0`, but `pnpm-lock.yaml` resolves all of these to local tarballs that are actually version `5.25.0`, `1.77.4`, and `1.77.4` respectively. After the local overrides are removed, the catalog entries should be bumped to the intended release versions so the lock file matches what the workspace declares.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>


2. `ui/src/pages/MainPage.vue`, line 33 ([link](https://github.com/platforma-open/clonotype-clustering/blob/a90ac7a141f703b724ddcd3ddf5fca1e56f39403/ui/src/pages/MainPage.vue#L33)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `sequencesRef` is typed as `ColumnUniversalId[]` and initialized to `[]`, so it is never `undefined`. The right-hand side of the `||` never fires, meaning the settings panel won't open when the sequence list is empty but the dataset is set.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: ui/src/pages/MainPage.vue
   Line: 33

   Comment:
   `sequencesRef` is typed as `ColumnUniversalId[]` and initialized to `[]`, so it is never `undefined`. The right-hand side of the `||` never fires, meaning the settings panel won't open when the sequence list is empty but the dataset is set.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
package.json:21-32
**Local machine paths committed to `pnpm.overrides`**

The new `pnpm.overrides` block resolves every key SDK and UI package to `file:../platforma_1/...` — a path that exists only on the author's machine. The regenerated `pnpm-lock.yaml` encodes these same local paths throughout its snapshots. Any `pnpm install` on CI or another developer's machine will fail immediately with a missing-tarball error. These overrides look like a local dev-iteration shortcut that was never meant to be pushed. The `//pnpm` (commented-out) block lower in the same file shows the prior pattern for keeping local overrides out of the committed file.

### Issue 2 of 4
pnpm-workspace.yaml:12-16
**Catalog version entries are stale relative to the installed local overrides**

The catalog still declares `@platforma-sdk/workflow-tengo: 5.24.0`, `@platforma-sdk/model: 1.77.0`, and `@platforma-sdk/ui-vue: 1.77.0`, but `pnpm-lock.yaml` resolves all of these to local tarballs that are actually version `5.25.0`, `1.77.4`, and `1.77.4` respectively. After the local overrides are removed, the catalog entries should be bumped to the intended release versions so the lock file matches what the workspace declares.

### Issue 3 of 4
model/src/index.ts:274
**Unchecked `axesSpec[1]` access**

`anchorSpec.axesSpec[1].name` is read directly without verifying that the spec has at least two axes. `datasetSelectors` does require exactly two named axes, so any correctly formed anchor column will satisfy this. However, if the SDK ever returns a spec with a single axis (e.g., due to an upstream bug or a future schema change), this line will throw `Cannot read properties of undefined (reading 'name')` inside the reactive output computation. A bounds check like `if (anchorSpec.axesSpec.length < 2) return undefined;` would prevent a hard crash. The same pattern appears in `isSingleCell` at line 347.

### Issue 4 of 4
ui/src/pages/MainPage.vue:33
`sequencesRef` is typed as `ColumnUniversalId[]` and initialized to `[]`, so it is never `undefined`. The right-hand side of the `||` never fires, meaning the settings panel won't open when the sequence list is empty but the dataset is set.

```suggestion
const settingsOpen = ref(app.model.data.datasetRef === undefined || app.model.data.sequencesRef.length === 0);
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Update type references and improve datas..."](https://github.com/platforma-open/clonotype-clustering/commit/a90ac7a141f703b724ddcd3ddf5fca1e56f39403) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37599987)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->