### PR TITLE
First version

### DIFF
--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -14,6 +14,7 @@ import {
   createPFrameForGraphs,
   createPlDataTableStateV2,
   createPlDataTableV2,
+  isPColumnSpec,
 } from '@platforma-sdk/model';
 export type * from '@milaboratories/helpers';
 
@@ -72,6 +73,11 @@ export type BlockData = {
   trimStart?: number; // number of amino acids to remove from the beginning
   trimEnd?: number; // number of amino acids to remove from the end
   clusteringTool: 'easy-cluster' | 'easy-linclust';
+  // Embedding-distance clustering. Single embedding column.
+  clusteringMethod: 'sequence' | 'embedding';
+  // PlRef (not a canonical/anchored id)
+  embeddingRef?: PlRef;
+  minClusterSize: number;
   mem?: number;
   cpu?: number;
   tableState: PlDataTableStateV2;
@@ -80,14 +86,29 @@ export type BlockData = {
   graphStateHistogram: GraphMakerState;
 };
 
-export function getDefaultBlockLabel(data: {
-  sequenceLabels: string[];
-  similarityType: BlockData['similarityType'];
-  identity: number;
-  coverageThreshold: number;
-  trimStart: number;
-  trimEnd: number;
-}) {
+// Single source of truth for the auto-subtitle (also the workflow trace label, main.tpl), one variant
+// per clustering method. The UI's syncDefaultBlockLabel (app.ts) only resolves the human-readable column
+// labels from the result pool (which a pure function can't do) and calls this; it owns no format logic.
+export function getDefaultBlockLabel(
+  data:
+    | {
+      clusteringMethod: 'sequence';
+      sequenceLabels: string[];
+      similarityType: BlockData['similarityType'];
+      identity: number;
+      coverageThreshold: number;
+      trimStart: number;
+      trimEnd: number;
+    }
+    | {
+      clusteringMethod: 'embedding';
+      embeddingLabel: string;
+      minClusterSize: number;
+    },
+) {
+  if (data.clusteringMethod === 'embedding') {
+    return `${data.embeddingLabel || 'Embedding'}, HDBSCAN, mcs:${data.minClusterSize}`;
+  }
   const parts: string[] = [];
   parts.push(data.sequenceLabels.join(' - '));
   parts.push(
@@ -113,6 +134,9 @@ const dataModel = new DataModelBuilder()
   .upgradeLegacy<OldArgs, OldUiState>(({ args, uiState }) => ({
     ...args,
     similarityType: (args.similarityType as string) === 'alignment-score' ? 'blosum62' : args.similarityType,
+    // Existing projects load in sequence mode (embedding mode is opt-in).
+    clusteringMethod: 'sequence',
+    minClusterSize: 5,
     tableState: uiState.tableState,
     graphStateBubble: uiState.graphStateBubble,
     alignmentModel: uiState.alignmentModel,
@@ -120,6 +144,7 @@ const dataModel = new DataModelBuilder()
   }))
   .init(() => ({
     defaultBlockLabel: getDefaultBlockLabel({
+      clusteringMethod: 'sequence',
       sequenceLabels: [],
       similarityType: defaultSimilarityType.value,
       identity: 0.8,
@@ -138,6 +163,8 @@ const dataModel = new DataModelBuilder()
     trimStart: 0, // default to no trimming from start
     trimEnd: 0, // default to no trimming from end
     clusteringTool: 'easy-cluster',
+    clusteringMethod: 'sequence', // embedding mode is opt-in (R1/R2)
+    minClusterSize: 5, // HDBSCAN; user-configurable, fixed small default, not scaled with N (R10)
     tableState: createPlDataTableStateV2(),
     graphStateBubble: {
       title: 'Most abundant clusters',
@@ -171,13 +198,35 @@ export const platforma = BlockModelV3.create(dataModel)
 
   .args((data) => {
     if (!data.datasetRef) throw new Error('Dataset is required');
-    if (!data.sequencesRef.length) throw new Error('Sequences are required');
-    return {
+
+    // Shared by both methods. The lambda branches on clusteringMethod and returns ONLY the active
+    // method's fields, so a stale off-mode value can't stale the block (V3 conditional suppression).
+    const shared = {
       defaultBlockLabel: data.defaultBlockLabel,
       customBlockLabel: data.customBlockLabel,
       datasetRef: data.datasetRef,
       sequencesRef: data.sequencesRef,
       sequenceType: data.sequenceType,
+      clusteringMethod: data.clusteringMethod,
+      mem: data.mem,
+      cpu: data.cpu,
+    };
+
+    if (data.clusteringMethod === 'embedding') {
+      if (!data.embeddingRef)
+        throw new Error('Connect a Sequence Embeddings output and pick an embedding column to cluster by embedding distance');
+      // sequencesRef is auto-derived from the embedding column (for centroid/MSA display) and may be
+      // empty; the embedding model is read from the column spec in the workflow, not snapshotted here.
+      return {
+        ...shared,
+        embeddingRef: data.embeddingRef,
+        minClusterSize: data.minClusterSize,
+      };
+    }
+
+    if (!data.sequencesRef.length) throw new Error('Sequences are required');
+    return {
+      ...shared,
       identity: data.identity,
       similarityType: data.similarityType,
       coverageThreshold: data.coverageThreshold,
@@ -186,8 +235,6 @@ export const platforma = BlockModelV3.create(dataModel)
       trimStart: data.trimStart,
       trimEnd: data.trimEnd,
       clusteringTool: data.clusteringTool,
-      mem: data.mem,
-      cpu: data.cpu,
     };
   })
 
@@ -287,6 +334,36 @@ export const platforma = BlockModelV3.create(dataModel)
           includeNativeLabel: true,
         },
       });
+  })
+
+  .output('embeddingOptions', (ctx) => {
+    const ref = ctx.data.datasetRef;
+    if (ref === undefined) return undefined;
+    // PlRef-based options (NOT getCanonicalOptions): the embedding's producer must be wired as an
+    // upstream via wf.resolve(PlRef), so the picker selects a PlRef. We scope to the current dataset by
+    // requiring the embedding's clonotype axis (axis 0) to match the dataset's clonotype axis (axis 1),
+    // and enrich each option with the embedding's `pl7.app/feature` so the UI can auto-derive the source
+    // sequence column(s) for the centroid (it has no spec for a bare PlRef).
+    const datasetSpec = ctx.resultPool.getPColumnSpecByRef(ref);
+    const cloneAxis = datasetSpec?.axesSpec?.[1];
+    if (cloneAxis === undefined) return undefined;
+    const sameClonotypeAxis = (embAxis?: { name?: string; domain?: Record<string, string> }) => {
+      if (embAxis === undefined || embAxis.name !== cloneAxis.name) return false;
+      const datasetDomain = cloneAxis.domain ?? {};
+      const embDomain = embAxis.domain ?? {};
+      return Object.keys(datasetDomain).every((k) => embDomain[k] === datasetDomain[k]);
+    };
+    const options = ctx.resultPool.getOptions(
+      (spec) => isPColumnSpec(spec)
+        && spec.name === 'pl7.app/embedding'
+        && sameClonotypeAxis(spec.axesSpec?.[0]),
+      { label: { includeNativeLabel: true } },
+    );
+    return options.map((o) => ({
+      ref: o.ref,
+      label: o.label,
+      feature: ctx.resultPool.getPColumnSpecByRef(o.ref)?.domain?.['pl7.app/feature'],
+    }));
   })
 
   .output('isSingleCell', (ctx) => {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "build": "turbo run build",
     "build:dev": "env PL_PKG_DEV=local turbo run build",
+    "build:dev-remote": "env PL_PKG_DEV=local PL_DOCKER_BUILD=1 PL_DOCKER_AUTOPUSH=1 turbo run build",
     "lint": "turbo run lint",
     "type-check": "turbo run type-check",
     "test": "env PL_PKG_DEV=local turbo run test --concurrency 1 --env-mode=loose",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11388,7 +11388,7 @@ snapshots:
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.6.3
+      semver: 7.8.4
       ts-api-utils: 2.0.1(typescript@5.6.3)
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -12330,7 +12330,7 @@ snapshots:
   eslint-compat-utils@0.5.1(eslint@9.39.2):
     dependencies:
       eslint: 9.39.2
-      semver: 7.6.3
+      semver: 7.8.4
 
   eslint-plugin-es-x@7.8.0(eslint@9.39.2):
     dependencies:
@@ -12349,7 +12349,7 @@ snapshots:
       globals: 15.14.0
       ignore: 5.3.2
       minimatch: 9.0.5
-      semver: 7.6.3
+      semver: 7.8.4
 
   eslint-plugin-vue@9.32.0(eslint@9.39.2):
     dependencies:
@@ -12359,7 +12359,7 @@ snapshots:
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.2
-      semver: 7.6.3
+      semver: 7.8.4
       vue-eslint-parser: 9.4.3(eslint@9.39.2)
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
@@ -13952,7 +13952,7 @@ snapshots:
       espree: 9.6.1
       esquery: 1.6.0
       lodash: 4.17.21
-      semver: 7.6.3
+      semver: 7.8.4
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,20 +10,20 @@ catalogs:
       specifier: ^2.29.8
       version: 2.29.8
     '@milaboratories/graph-maker':
-      specifier: 1.4.5
-      version: 1.4.5
+      specifier: 1.4.6
+      version: 1.4.6
     '@milaboratories/helpers':
       specifier: 1.14.2
       version: 1.14.2
     '@milaboratories/multi-sequence-alignment':
-      specifier: 1.47.15
-      version: 1.47.15
+      specifier: 1.47.16
+      version: 1.47.16
     '@milaboratories/strings':
       specifier: 0.1.2
       version: 0.1.2
     '@milaboratories/ts-builder':
-      specifier: 1.5.0
-      version: 1.5.0
+      specifier: 1.5.1
+      version: 1.5.1
     '@milaboratories/ts-configs':
       specifier: 1.2.3
       version: 1.2.3
@@ -34,29 +34,29 @@ catalogs:
       specifier: 1.18.0
       version: 1.18.0
     '@platforma-sdk/block-tools':
-      specifier: 2.10.5
-      version: 2.10.5
+      specifier: 2.10.17
+      version: 2.10.17
     '@platforma-sdk/eslint-config':
       specifier: 1.2.0
       version: 1.2.0
     '@platforma-sdk/model':
-      specifier: 1.78.4
-      version: 1.78.4
+      specifier: 1.79.6
+      version: 1.79.6
     '@platforma-sdk/package-builder':
-      specifier: 3.12.0
-      version: 3.12.0
+      specifier: 3.13.0
+      version: 3.13.0
     '@platforma-sdk/tengo-builder':
-      specifier: 4.0.5
-      version: 4.0.5
+      specifier: 4.0.8
+      version: 4.0.8
     '@platforma-sdk/test':
-      specifier: 1.78.4
-      version: 1.78.4
+      specifier: 1.79.7
+      version: 1.79.7
     '@platforma-sdk/ui-vue':
-      specifier: 1.78.4
-      version: 1.78.4
+      specifier: 1.79.6
+      version: 1.79.6
     '@platforma-sdk/workflow-tengo':
-      specifier: 6.3.0
-      version: 6.3.0
+      specifier: 6.6.0
+      version: 6.6.0
     eslint:
       specifier: ^9.25.1
       version: 9.39.2
@@ -85,7 +85,7 @@ importers:
         version: 2.29.8(@types/node@24.5.2)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.10.5
+        version: 2.10.17(@types/node@24.5.2)
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -110,13 +110,13 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.10.5
+        version: 2.10.17(@types/node@24.5.2)
 
   model:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.5(@milaboratories/pl-model-common@1.45.0)(@platforma-sdk/model@1.78.4)(@platforma-sdk/ui-vue@1.78.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.6(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.6(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/helpers':
         specifier: 'catalog:'
         version: 1.14.2
@@ -125,17 +125,17 @@ importers:
         version: 0.1.2
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.78.4
+        version: 1.79.6
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.5.0(@types/node@24.5.2)(rollup@4.53.5)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.1)
+        version: 1.5.1(@types/node@24.5.2)(rollup@4.53.5)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.1)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
         version: 1.2.3
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.10.5
+        version: 2.10.17(@types/node@24.5.2)
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.2.0(@eslint/js@9.39.2)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-n@17.15.1(eslint@9.39.2))(eslint-plugin-vue@9.32.0(eslint@9.39.2))(eslint@9.39.2)(globals@15.14.0)(typescript-eslint@8.24.0(eslint@9.39.2)(typescript@5.6.3))(typescript@5.6.3)
@@ -156,7 +156,7 @@ importers:
         version: 1.7.3
       '@platforma-sdk/package-builder':
         specifier: 'catalog:'
-        version: 3.12.0
+        version: 3.13.0
 
   test:
     dependencies:
@@ -166,7 +166,7 @@ importers:
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.5.0(@types/node@24.5.2)(rollup@4.53.5)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.1)
+        version: 1.5.1(@types/node@24.5.2)(rollup@4.53.5)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.1)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
         version: 1.2.3
@@ -175,7 +175,7 @@ importers:
         version: 1.2.0(@eslint/js@9.39.2)(@stylistic/eslint-plugin@2.13.0(eslint@9.39.2)(typescript@5.6.3))(eslint-plugin-n@17.15.1(eslint@9.39.2))(eslint-plugin-vue@9.32.0(eslint@9.39.2))(eslint@9.39.2)(globals@15.14.0)(typescript-eslint@8.24.0(eslint@9.39.2)(typescript@5.6.3))(typescript@5.6.3)
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.78.4(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
+        version: 1.79.7(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
       eslint:
         specifier: 'catalog:'
         version: 9.39.2
@@ -190,10 +190,10 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.5(@milaboratories/pl-model-common@1.45.0)(@platforma-sdk/model@1.78.4)(@platforma-sdk/ui-vue@1.78.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.4.6(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.6(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/multi-sequence-alignment':
         specifier: 'catalog:'
-        version: 1.47.15(@milaboratories/pl-model-common@1.45.0)(@platforma-sdk/model@1.78.4)(@platforma-sdk/ui-vue@1.78.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
+        version: 1.47.16(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.6(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -202,17 +202,17 @@ importers:
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.78.4
+        version: 1.79.6
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.78.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+        version: 1.79.6(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       vue:
         specifier: 'catalog:'
         version: 3.5.24(typescript@5.6.3)
     devDependencies:
       '@milaboratories/ts-builder':
         specifier: 'catalog:'
-        version: 1.5.0(@types/node@24.5.2)(rollup@4.53.5)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.1)
+        version: 1.5.1(@types/node@24.5.2)(rollup@4.53.5)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.1)
       '@milaboratories/ts-configs':
         specifier: 'catalog:'
         version: 1.2.3
@@ -239,11 +239,11 @@ importers:
         version: 1.18.0
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 6.3.0
+        version: 6.6.0
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 4.0.5
+        version: 4.0.8
 
 packages:
 
@@ -904,8 +904,133 @@ packages:
     resolution: {integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==}
     engines: {node: '>=18.18'}
 
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/checkbox@4.3.2':
+    resolution: {integrity: sha512-VXukHf0RR1doGe6Sm4F0Em7SWYLTHSsbGfJdS9Ja2bX5/D5uwVOEjr07cncLROdBvmnvCATYEWlHqYmXv2IlQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@4.2.23':
+    resolution: {integrity: sha512-aLSROkEwirotxZ1pBaP8tugXRFCxW94gwrQLxXfrZsKkfjOYC1aRvAZuhpJOb5cu4IBTJdsCigUlf2iCOu4ZDQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@4.0.23':
+    resolution: {integrity: sha512-nRzdOyFYnpeYTTR2qFwEVmIWypzdAx/sIkCMeTNTcflFOovfqUk+HcFhQQVBftAh9gmGrpFj6QcGEqrDMDOiew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/input@4.3.1':
+    resolution: {integrity: sha512-kN0pAM4yPrLjJ1XJBjDxyfDduXOuQHrBB8aLDMueuwUGn+vNpF7Gq7TvyVxx8u4SHlFFj4trmj+a2cbpG4Jn1g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@3.0.23':
+    resolution: {integrity: sha512-5Smv0OK7K0KUzUfYUXDXQc9jrf8OHo4ktlEayFlelCjwMXz0299Y8OrI+lj7i4gCBY15UObk76q0QtxjzFcFcg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@4.0.23':
+    resolution: {integrity: sha512-zREJHjhT5vJBMZX/IUbyI9zVtVfOLiTO66MrF/3GFZYZ7T4YILW5MSkEYHceSii/KtRk+4i3RE7E1CUXA2jHcA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@7.10.1':
+    resolution: {integrity: sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@4.1.11':
+    resolution: {integrity: sha512-+LLQB8XGr3I5LZN/GuAHo+GpDJegQwuPARLChlMICNdwW7OwV2izlCSCxN6cqpL0sMXmbKbFcItJgdQq5EBXTw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@3.2.2':
+    resolution: {integrity: sha512-p2bvRfENXCZdWF/U2BXvnSI9h+tuA8iNqtUKb9UWbmLYCRQxd8WkvwWvYn+3NgYaNwdUkHytJMGG4MMLucI1kA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@4.4.2':
+    resolution: {integrity: sha512-l4xMuJo55MAe+N7Qr4rX90vypFwCajSakx59qe/tMaC1aEHWLyw68wF4o0A4SLAY4E0nd+Vt+EyskeDIqu1M6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
@@ -994,19 +1119,15 @@ packages:
   '@milaboratories/biowasm-tools@2.0.3':
     resolution: {integrity: sha512-/X2PJ9VYmVKHZ12X7p2lgzEN+zqeycatVGdVA1ifsdBXE4bKNmCrWhUr4JRlpoB5wuj/J5chBbIi6N9y6Tk1aw==}
 
-  '@milaboratories/computable@2.9.4':
-    resolution: {integrity: sha512-MgUqC3/8cE41k01dV8yne+K0bUYA457XFP7b/Sf5QrxDp6zWqCpWuCgLlsUzJNzFFLXaODWnpAFUvOZyQcq4jg==}
+  '@milaboratories/computable@2.9.5':
+    resolution: {integrity: sha512-rzLJ6fjXcNL8jb6vexGR4d8wUGvrwC2CyjkMLU5GFy+7Q6lg1wTrJnu8fzDVhS2OjEEVbD+RTE7AGvK5pYYSMQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/graph-maker@1.4.5':
-    resolution: {integrity: sha512-ArsWNhBg9bna+RM9C9hLa6GlfTKQUbJWA2VYVQsaDDGzIN8GUqCB7M44q/codGI6jai3AcIl8AXpOKq2Vl8ZyQ==}
+  '@milaboratories/graph-maker@1.4.6':
+    resolution: {integrity: sha512-0DNyErBXJo6l3o7pF8awBuNaOy9Z7sK3SHy8xMtC2PBaXKsOGWPNXnqephOIrRWqyQMAL9A+rA3bzHQKf4TcVg==}
     peerDependencies:
       '@platforma-sdk/model': 1.73.3
       '@platforma-sdk/ui-vue': 1.73.3
-
-  '@milaboratories/helpers@1.14.1':
-    resolution: {integrity: sha512-GcxeGHakSLhewbA7hd8YVHnEzyi95UnzcZhgwvRPO+W7/svZc8sAGidAV5xgN/YmVmJfCRl7hfiIcL37+fm0Ew==}
-    engines: {node: '>=22'}
 
   '@milaboratories/helpers@1.14.2':
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
@@ -1015,95 +1136,95 @@ packages:
   '@milaboratories/miplots4@1.2.2':
     resolution: {integrity: sha512-VMdMxfD/lwObssvYDFRnBcBAV4JFqI2FsoQqmJ/wurIHieoZLU9K0UO57MvsvtmO3Deb9swUjuDUJ+jAe8isqw==}
 
-  '@milaboratories/multi-sequence-alignment@1.47.15':
-    resolution: {integrity: sha512-1l4mgX7S4op6PffGQ5NDJfiaQFp6MMLkeK06hRapxtT67FHctxFPuTVufLBX1RmHMX0kRmIK68CqBl1L6+aaYA==}
+  '@milaboratories/multi-sequence-alignment@1.47.16':
+    resolution: {integrity: sha512-wXiDfzTSOjcImzSgTxplSVAF/MaKJn53JlEgV+A69irBEbwN32vanjYCNILIFzzG5jHhwGTCBCAoqjJJ30a4fQ==}
     peerDependencies:
       '@platforma-sdk/model': 1.73.3
       '@platforma-sdk/ui-vue': 1.73.3
 
-  '@milaboratories/pf-driver@1.7.0':
-    resolution: {integrity: sha512-lfasw6sQ/lKtp9KBwQc7c+pw0tpog5TCOzckj/SFzoIDak/n1VTZaYNtD95dcgSz3KCimQ3duGPoT3RLuN5mJw==}
+  '@milaboratories/pf-driver@1.7.10':
+    resolution: {integrity: sha512-UcHxrIfjSJSqXNCp5eFYFTLar2vzkwjvpCKQoKnYWMHb1B4EaryL/7wEaLmA+c6rOEaaj7Y/ZhNG+eXrMa2YEg==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pf-plots@1.4.3':
-    resolution: {integrity: sha512-Yyf+nUW3q4LOjU1pPUAVlCPNGIGzyjYY5kaOTSrwehJbOk1W+Da0TSziOWALkAAonpi1id2BY5XGb0PQtZ95Eg==}
+  '@milaboratories/pf-plots@1.4.4':
+    resolution: {integrity: sha512-FElw8BGbp7vRXPXpHlH66ahf3c+y83Gxozr7npSXyvYx+qiiu/SElLwP29EUdAfeB3z/nIL4cOb13W+lxd7u9Q==}
     peerDependencies:
       '@milaboratories/pl-model-common': 1.39.0
       '@platforma-sdk/model': 1.73.3
 
-  '@milaboratories/pf-spec-driver@1.4.3':
-    resolution: {integrity: sha512-xqgV9Bg+BF1pHcL6J46zk814fYsKW8Qq/ukzlOfFAD6bH5y29Ydt3AdTrsrAhax3sdmqAgFwjMB0mT04ePl7tg==}
+  '@milaboratories/pf-spec-driver@1.4.12':
+    resolution: {integrity: sha512-WuSBrx/F62LPcNO6DU0lkW04HMpfIpVCU3xIoTYfIeXXcCibUPebw9hVvWpteSjfF6V69EjisxEuPrxd44HecA==}
 
-  '@milaboratories/pframes-rs-node@1.1.41':
-    resolution: {integrity: sha512-gC9LaukKQhFlaY2ciV/ZTyiKqhIYHYaj4PerFWRc8Xnv339ABFLZooh+Q8aI8ylhHE+4klvFL0Eidg32k0jokw==}
+  '@milaboratories/pframes-rs-node@1.1.46':
+    resolution: {integrity: sha512-TYvlvW3E59LXdfLrkklmJF1Eb29oxIrP6CTbE/RQxHrcBw0kkDUaR+VG2L/b+OQRTORi9YNrqJhWzhJOIrPWFQ==}
 
-  '@milaboratories/pframes-rs-serv@1.1.41':
-    resolution: {integrity: sha512-OnSL43+SJDOCgzHgQIhawS6nxe7ZfM3gOefHFJhe3t6L42bWJFF+8rUUPWbF+DybMXQuDBIOU8v4iwLJGsaQ5Q==}
+  '@milaboratories/pframes-rs-serv@1.1.46':
+    resolution: {integrity: sha512-0ohN+yvePXG4pP6TY9S0N5mrP1WYSjv30iKk1VjlCTW2HqjyMa7MPGsnJaVX3BVUzB7IQJs0BZ5GP3oHsEZm6g==}
     hasBin: true
 
-  '@milaboratories/pframes-rs-wasip2@1.1.41':
-    resolution: {integrity: sha512-90sD8WotapOKK/pjmMOsPHnlJ3qMfXbqJwdHfPyUEKHJLsrEYNatGdvHbRzCfPy6Sxl/yE1Bx1nzzEwcaIPyrw==}
+  '@milaboratories/pframes-rs-wasip2@1.1.44':
+    resolution: {integrity: sha512-lS8poGIpnGK+w2LKwbmYGuT4khXVK0qeXOQpo9b7wyTgAMJmjFcV/MBlS7ql5cJ/NS86p27cZDBBAlEgfBFWfw==}
 
-  '@milaboratories/pframes-rs-wasm@1.1.41':
-    resolution: {integrity: sha512-pl0jL1nS5hM9AHwTUuX3pf9W0EfbcydlZTSuDdKy6MOnrs1nnEUzY6pS+p+bnxKofhHM/LYwmbDKZiX/XCKoew==}
+  '@milaboratories/pframes-rs-wasip2@1.1.46':
+    resolution: {integrity: sha512-aKKcPzyud13WmiEV2+2lbT0/qcuPJx/d3yztoXZHU++gwDRu1LXq2c/hjphYMPQ/g2zDXewMtzeBHknypi95UQ==}
+
+  '@milaboratories/pframes-rs-wasm@1.1.46':
+    resolution: {integrity: sha512-1NJ4PTzTuXUfNCiYCkOvclP34SPTXRVJei5vHmPt4guawX/u8m+zYhyQcnARZoDGMV21VNuxTPAeqRzBPSzr3w==}
     peerDependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
-      '@milaboratories/pl-model-common': 1.43.0
-      '@milaboratories/pl-model-middle-layer': 1.27.0
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.4
 
-  '@milaboratories/pl-client@3.11.1':
-    resolution: {integrity: sha512-ogWap6lRKJUldSqS7Hgk332wgp1I0MEocqAtoS1819Dn1JZ6iiUo56dqma8TDuH7m088uQmC6uf9cLgHwhDNag==}
+  '@milaboratories/pl-client@3.11.4':
+    resolution: {integrity: sha512-tsbZLVBC3qr3bcJ1mAvkKSJSjrOkh+OzI4EACOZ8V9eS1M08ooDF5L2JkhUPceCsNr78vgkffZFwwHIbPMtHrA==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-config@1.8.1':
-    resolution: {integrity: sha512-moh8YNeSXRkBaH5IQhrzcWoehM6EMwfVFx2Y4vP6eEwphbHDqPLdhn6COkEJlYijH6kT00JdWjlUrvx+MZD9Cw==}
+  '@milaboratories/pl-config@1.8.2':
+    resolution: {integrity: sha512-FG9rlAKDf1rwlg+3G9OG2bCKISNp6ajM27W7ODDSsWE4MSCVxhYB172UusbohY2RDmaD9GI5pDKO5O9uoHQCCA==}
 
-  '@milaboratories/pl-deployments@3.0.4':
-    resolution: {integrity: sha512-Lk0CgBYc2XdIaOQqfvmyvwDpVGwFyDEoxbr+WIBndG6HXbavilLKGhrRAWkjcnUVBPbW/4lfQCZUryaP8VaGGg==}
+  '@milaboratories/pl-deployments@3.0.7':
+    resolution: {integrity: sha512-llf3PeNr7/+t7I4LDwgSzqt+fcrV8YWbzv1LWJXUXOL2VF3wArBoSLmzFr3SiRD5hIUcCDEA3QHWXwXTzth0kQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-drivers@1.15.3':
-    resolution: {integrity: sha512-md98t08A7bBEXEU/QyUkT36KdINa5EmPbM+csDJwryg39bbbawSIBpjeHqoAHVtI7zYNmEtCtablNPGahF4ewA==}
+  '@milaboratories/pl-drivers@1.15.6':
+    resolution: {integrity: sha512-AAD5t/qSBi2upmeQvt296mG1cDT1afmpqwcXuySj7mu+DZWG+l/c8NHh8DV1yZlsM3sIlOFHPHhN4wSYMsvJmg==}
     engines: {node: '>=22'}
 
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
-  '@milaboratories/pl-errors@1.4.19':
-    resolution: {integrity: sha512-SzV/ni1Bb+PRHuyHC18F4FzR9x5Kf5cl38ZnCo/3uTNThHutDFXRWfpaAZUxehTKQH5OGVurJAKWxxJWxb2Zqw==}
+  '@milaboratories/pl-errors@1.4.22':
+    resolution: {integrity: sha512-A4jEhyXEeHb03aRpUGWxILGTfNwYii/BgmoZ3TVv5q0iWnApoiVUoy/MXtaed4QeUs8FZlOhZfOO5AKq1yaXrQ==}
 
-  '@milaboratories/pl-healthcheck@1.0.0':
-    resolution: {integrity: sha512-tuSg+bwacmt9Z5gOkiarmX7jwYJttA+9rqXKaatwnPgjP+nAI40hyZtOZPHzJFEzWd4AKaGxrJbNxdB/xMG/ww==}
+  '@milaboratories/pl-healthcheck@1.0.1':
+    resolution: {integrity: sha512-eiYd/TFm18SW4EY8vkI3c+fcPnjUu3Hd1GnPLWCN8U+dNmp/tnrzfeCgaY4xO/s0vkHNX9E7IrsQiMg2Ioz4rw==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.64.6':
-    resolution: {integrity: sha512-l5RIpEYgE/Qw1HcrvBZeGKzJ1najR7rk3C5VOKyL5LHiGFLtk7uE7xFRZrTXeHVNK+0Ks1Ip8Ih/EJV8oq6OSw==}
+  '@milaboratories/pl-middle-layer@1.64.25':
+    resolution: {integrity: sha512-+06T+LgRxG2240gDsEhg4k06yB0s6awvojr7AF2C6f1JU+tU/Ld/RZAQGmbs9iuKpkE43gDz5NH/6vk5BrBWPg==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-model-backend@1.4.4':
-    resolution: {integrity: sha512-4vwPqUzo1VnaDi2pFpkNtdqKZBOEDHwG7UpWrKYLO8cWZIZDERbJupGHvM1xt8WamrcRT+CMLyL2yNIJ+eXQnQ==}
+  '@milaboratories/pl-model-backend@1.4.7':
+    resolution: {integrity: sha512-OSe9s7HJ5bVbggG9gF5/sPnvW3gqQsICeIQeT+pe2i/HvxNoL/YNvvJhcNaGc3D+TNKzu4GIlaWaRQfiYffzNQ==}
 
-  '@milaboratories/pl-model-common@1.43.0':
-    resolution: {integrity: sha512-iXDytbsIy6fd2zRFqDbZceuxDpBmGH9wS2UDHpT3PAxmnneBBddW4/VILWw4HLzzXhvXYOz3FpGl/CNc76pTJQ==}
+  '@milaboratories/pl-model-common@1.46.1':
+    resolution: {integrity: sha512-ABOz/w7dA4t2zUpZHXI74MTNW6LmPFSLxgfhOPFdO6vodIY8draVN+ag2U21WlYIoSgdJwSXJrXJWdu1cefrIg==}
 
-  '@milaboratories/pl-model-common@1.45.0':
-    resolution: {integrity: sha512-T3yCPY112J/+b5OjK2qVaJ/sk5rdyA8GNa87YojwZmO9P8KAgngOZrnjmBTnyW3Z64iK4N6Lt64+c0AnPB9sig==}
+  '@milaboratories/pl-model-middle-layer@1.30.4':
+    resolution: {integrity: sha512-U81Fk33PFBxBDTt8s1Ue31z1yM4Yx8ZOPu0SrANT8oevlIfgDYZHEtPzPfUBprh3Yq4/4VrEqkRpTLbP6I6s4g==}
 
-  '@milaboratories/pl-model-middle-layer@1.27.0':
-    resolution: {integrity: sha512-nDMBkj7P6JG+LfqeoR4nhmQiA77cAtvXSMvsV5ijsgZT8+A7Am+JXiwgHsii7vC9VvfSV80SUrv0MCvFrwR9qQ==}
+  '@milaboratories/pl-model-middle-layer@1.30.6':
+    resolution: {integrity: sha512-x6cj1sNAayz80odDf6RbXnJDgj01Lc+NB+5IVyMk65o3cGt6ml0IbiqaDXGMJYUDkt1JSAj3EQpPha2YDDfYQg==}
 
-  '@milaboratories/pl-model-middle-layer@1.29.0':
-    resolution: {integrity: sha512-xUZnvi6yvU2iegXxU/alECmyxlG0RZxRP5gcUO9CfJ3kmx48NFYmDSLsolxtmunV0GYsMb3HjeMMe2oiH6ey7w==}
-
-  '@milaboratories/pl-tree@1.12.9':
-    resolution: {integrity: sha512-VcpZic94VutSAFhVEmNgyFps0r+l3VsjNz2wwU+LUv4FEgT+Z6191n+hIr1EAoQqWm/Uk5nEgi2pAohrpB2gwg==}
+  '@milaboratories/pl-tree@1.12.12':
+    resolution: {integrity: sha512-IREZbJZ1F7QerUyzcfPg0HQCae/FPGXoNbxwsecLC+JiPAVaRdcz+uNTpBlPVNEeI9BT88fJmDhfjts5bbeE7A==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/ptabler-expression-js@1.2.28':
-    resolution: {integrity: sha512-f7OcBgCEfypdBw1jHvZtBg7WKCsuPc1huHjYsYRfuFBj0+df6CfSLM0hr5jDyGwjS8raOmg4rN1Jdbei0tj2HA==}
+  '@milaboratories/ptabler-expression-js@1.2.30':
+    resolution: {integrity: sha512-6yRo0T6rpt14WEC++F+uuFGunnGF8ApCeKnvkysTsKxo+hALGPIQbobcTFN1gtQADnK6DI6huWQ6MxQpjBgbuQ==}
 
   '@milaboratories/resolve-helper@1.1.3':
     resolution: {integrity: sha512-38/dW/XRZQREOxAOOKtO0lzEWPCP/DH0qhB3q1kYcGoN++5V92/zbVwbYrMDeDcjTyo+D62iIep+sKXeWHa7Uw==}
@@ -1119,22 +1240,22 @@ packages:
     os: [darwin, linux, win32]
     hasBin: true
 
-  '@milaboratories/ts-builder@1.5.0':
-    resolution: {integrity: sha512-tSLwqZ5dfmiXwriCYh2LI++N3AfB2RR5E30TSQRYd1ovC9fMZ9eGCZ3WskQ1h0p5+dUeSKGkDlgZFNF1wO1TTQ==}
+  '@milaboratories/ts-builder@1.5.1':
+    resolution: {integrity: sha512-Mx/mR3tO5hD85qhDr+ZffXV7dg0ILucTeoz4TVRwkup+1HpTE6XDTYXcenTID4hQKzRAbTwkBiWM9qnWwm6UEA==}
     hasBin: true
 
   '@milaboratories/ts-configs@1.2.3':
     resolution: {integrity: sha512-NALtuzTbSzAz2Uk7X1sWq3rBo4XAV/vAQ1Mf7IfiNiv1euZ+0+TF0NDJMNiEcU6BT/Q55dATSKhIY2r680ljXw==}
 
-  '@milaboratories/ts-helpers-oclif@1.1.41':
-    resolution: {integrity: sha512-rpn1jB2b6p4hcw4Y2iuLM/9X9zqGXacRL1RbZMaB6ebk+2bnmH3CtmfJJdBWW1wfsP80HqmRV8iQrfCI1kzFDA==}
+  '@milaboratories/ts-helpers-oclif@1.1.42':
+    resolution: {integrity: sha512-qbhoxfOXG3SeODsgEcedf4WMHVJVFXdgBgK2zIvkB+vC5OTBjZKo0MSo1ILRXovR5C319BCo0no7SNZY8l+3vw==}
 
-  '@milaboratories/ts-helpers@1.8.2':
-    resolution: {integrity: sha512-bQHcEAeJXyV95Gyk0yoRS5t3M71mFaNG+SsY2o+i4GDDeByUXBiF+T5A0elc/rCyLK6NNlOblou0DHBYOiW3pQ==}
+  '@milaboratories/ts-helpers@1.8.3':
+    resolution: {integrity: sha512-HK3AmNZl2fOzMHot2+ihKsOC+fluwhl5261VTn1zGS3LRpmC9bCk/po8SzsVmg79ccI5nESFTdz+BRaLsXncmQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.14.22':
-    resolution: {integrity: sha512-QFLXZEXWaFl/OOEGu+xEMwsgsvpp/uqWBv0wum6bJJrlDwudiSlqsB9U2v0z/JkA3LI6+jh26c+NN5g3K+Fjjg==}
+  '@milaboratories/uikit@2.15.7':
+    resolution: {integrity: sha512-R1bHkxgYokVB7QKkVTAC3Zmdv2acskOGqd/vw/tpg0xsGKO2aUQ4k+gEp0dEsC4yf4nA0zU9Dd6oNGJ1NA3NeQ==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -1456,11 +1577,11 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3@1.7.3':
     resolution: {integrity: sha512-PQQnh2Gb4EXN4afcKTj/H4HSlOvm03F24GRe2HwHQkKfZt8Td8jrDhO8AtMPQtSCbKDEKAQXMD0J2ybGXb6Vvg==}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.12':
-    resolution: {integrity: sha512-oKi1VEsHuaygocBj5FrEUdLmMyBL9Z3Y6rnsArrhclnJuGGoxNC7zun5t+jeaGXCboCvpGQaLwz9mmiWStt65g==}
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.14':
+    resolution: {integrity: sha512-BBbmfUi3fS40HmMbYKGuRNgSPo4kAk/vk+dUK3fyabbjGncKZTm9W4vZlqH2JJX0VECIROR4FrvGvF91yRyVwg==}
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.0':
-    resolution: {integrity: sha512-hxmUV8kDFgfHtJuRTwIEwsVbFfT06imjnZbf+Ycbt2iopqKpZGOZXvlLKSVrEl1oYcZBMovGrTZmOs7mKgyfXQ==}
+  '@platforma-open/milaboratories.software-ptabler@2.1.1':
+    resolution: {integrity: sha512-s1Mqs/zHYXHFqQpXCDsqEKDrZr8auhNz32JciU2CTTFxbVzm6QCHpZNh7gLpyc74YK3Nrfcy1fjl/8GMreNMNA==}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2':
     resolution: {integrity: sha512-I08YpKQ4+esLrfpVra5UJ+bznI9Zzba6OW0rKK407a1EUmanvYMVrCbM9gqnm6CHbv2vQxNGSaO8p1LoBh+9gA==}
@@ -1471,20 +1592,23 @@ packages:
   '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.7':
     resolution: {integrity: sha512-CqXbfFld2l6Y/8rtcZXRPsa5kqNnaS3QWUxrcfMYwNxultbhLzjZGdqSR7ejV9xRWilXpeg6DdZJIKF3+KDH8g==}
 
+  '@platforma-open/milaboratories.software-small-binaries.line-counter@1.1.1':
+    resolution: {integrity: sha512-3bqn2ZK/dV5IR0Zp678Ea9lGSHjLvfRv4lyRBYXZNO1mMWIlEhtT0bmn6FhNzBBj+MhTQfSRFnEsOejtfdN1Ew==}
+
   '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.5':
     resolution: {integrity: sha512-ZdVg77pZ0Hgvxdk+mYahEyPbcTzDyz6Y7qlm6A0rJw8WCYmDVkfLqctQj0QkTLHM76oSWOHJIgD07ZxORjjgwA==}
 
   '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.5':
     resolution: {integrity: sha512-x6WOZ8S3uLXzmwliCF500hw7VQ4A9U3VBbESjJlPia26aU91FqB3ylKyH2fEyTiVw2wADlTYuui1tHX47iS5Lw==}
 
-  '@platforma-open/milaboratories.software-small-binaries@2.0.4':
-    resolution: {integrity: sha512-q8dAJ/RwAR35uKj74Bvzq4lpuBLxzuCNkuCH4suwb2ybDyEggL0XUB26aUuf15hX+6rFVulyBaQToXURKVKwzw==}
+  '@platforma-open/milaboratories.software-small-binaries@2.1.1':
+    resolution: {integrity: sha512-KN1PR7YgUUfx1dxh/TtcoWpSZbOXbRxXzQuJ505qHuXuE0spYwC7bXnvJsEYbEwRcPMa0foTrjBnPNORE4yr+Q==}
 
   '@platforma-open/soedinglab.software-mmseqs2@1.18.0':
     resolution: {integrity: sha512-qZw1HPzF1TCjQXmckGUHK5o7/ErVomiY+Ink1Jj44GS8j+lG+LPoJvqVjtFSxUm9fCdzfQg6rCC78tbS/JiPpw==}
 
-  '@platforma-sdk/block-tools@2.10.5':
-    resolution: {integrity: sha512-8xagUM2yjsUNXBYTVgvIBapzmheBlgCFc+8dmw57LG7S6lkXFRtWPes6wGWdhDFFPq/Lo3O/F/X20gh0dpkt0g==}
+  '@platforma-sdk/block-tools@2.10.17':
+    resolution: {integrity: sha512-bwpAwDyR6G8iZeGRkWc/gVfiXAsjxW14AWPtY4/uoHr3lRYJQOZy1+/hBsgXJPyoIHpoegnXJLgCDTLDyIfadQ==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -1503,26 +1627,26 @@ packages:
       typescript: ~5.6.3
       typescript-eslint: ^8.17.0
 
-  '@platforma-sdk/model@1.78.4':
-    resolution: {integrity: sha512-2Q5wB4lfurtSrix88kiMVR377JsEKdJqc9KBtKMAEG7rZQiotkmh52Dfke5lw2Ye/zgQ+napvhLlk3T7dkcLXg==}
+  '@platforma-sdk/model@1.79.6':
+    resolution: {integrity: sha512-aLgxJQQj07+uNYXiQHvFwFG34tgDC+NxvihMJ89dYKdgLPGDMlamIN4bxXco4W3uFqujQNTOqMed7cMeF3UYxA==}
 
-  '@platforma-sdk/package-builder@3.12.0':
-    resolution: {integrity: sha512-bId52YqV5iLDAn9D9C3xaLD1bKyymGpHe2CDEZTqV+1yWCBh1RM6iH96JIXudVJdcmJaqwJWDw6X4WzStE6SCg==}
+  '@platforma-sdk/package-builder@3.13.0':
+    resolution: {integrity: sha512-5dMFx1S8cotsWd9rccJlyRH00j43f9JFzLmuMGqwKCdfv+T0TADBWvbFRv1oD+kr5gRGj++Ud5GUIVVUUr6suw==}
     hasBin: true
 
-  '@platforma-sdk/tengo-builder@4.0.5':
-    resolution: {integrity: sha512-X743T2atcjA3JrZbzK7jTTaEOul7eJdggz0BPpu3d3I+OrjVkceqTYQzCSc1gwNYU1UHdo3bZwzic8rwVlW60Q==}
+  '@platforma-sdk/tengo-builder@4.0.8':
+    resolution: {integrity: sha512-FOMj0LCBRWHKuKKOHUxqZX3uhaC4OayGzw0YBxbye0b7d7uwhH2KjdrkO70uHRy64z4U85pjIR2TrwAQC8qUgQ==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.78.4':
-    resolution: {integrity: sha512-89cpKE0jzh5KvviWqDWvZW8RM0VppY0mhscr9rP9YU+qenFTuN6Yb83FxDq9x0cl2NIZnghI/NvxSisKROXXjw==}
+  '@platforma-sdk/test@1.79.7':
+    resolution: {integrity: sha512-pwGJ15pU9AsDVOwoE54bkndTi3VKM9tEX/Su7SFiA4OhQqhyPrPrwou1mhawQgmlhtN3duhSOdNQu9o2vbR04w==}
 
-  '@platforma-sdk/ui-vue@1.78.4':
-    resolution: {integrity: sha512-Ywb0M1F8zWTGvJBi5Iz39MGOZowzqePYjh7gdW5P2Rtd91TzRAYjxQ9oahnCNGb4ER3WmrU0Cf7RmFRdajh0aw==}
+  '@platforma-sdk/ui-vue@1.79.6':
+    resolution: {integrity: sha512-JU/erzLrz/81YnPq7BUJ+TK/9piIvg1eivBrgeFOCkaI8iMvaGaCEVeWa+zetkOwM3X1HM4UKA66nf1V7wuCZA==}
 
-  '@platforma-sdk/workflow-tengo@6.3.0':
-    resolution: {integrity: sha512-jtljm+Ytx8SeWSKt7zl3VXjI/PxBN2VkWR5oLpW2YU5K+CZxY6sZBrsMEAa4gTztK/rDdUrx4ynSX3QI+tGm0g==}
+  '@platforma-sdk/workflow-tengo@6.6.0':
+    resolution: {integrity: sha512-HHKmku2ujsEVFdR/ze29H2mtSDp7P0QwBNRNjWrWuqUoFG42y59xOgTD8Id6kad4WGxtmdp38EtJOM5QtBNIug==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -3717,8 +3841,8 @@ packages:
       typescript:
         optional: true
 
-  '@vue/language-core@3.2.7':
-    resolution: {integrity: sha512-Gn4q/tRxbpVGLEuARQ43p3YELlNAFgRUVCgW9U5Cr+5q4vfD2bWDWpl3ABbJMXUt5xlE1dF8dkigg2aUq7JYYw==}
+  '@vue/language-core@3.2.6':
+    resolution: {integrity: sha512-xYYYX3/aVup576tP/23sEUpgiEnujrENaoNRbaozC1/MA9I6EGFQRJb4xrt/MmUCAGlxTKL2RmT8JLTPqagCkg==}
 
   '@vue/reactivity@3.5.24':
     resolution: {integrity: sha512-BM8kBhtlkkbnyl4q+HiF5R5BL0ycDPfihowulm02q3WYp2vxgPcJuZO866qa/0u3idbMntKEtVNuAUp5bw4teg==}
@@ -4100,6 +4224,10 @@ packages:
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -5148,6 +5276,10 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   nan@2.22.0:
     resolution: {integrity: sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==}
 
@@ -5594,6 +5726,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.4:
+    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   shebang-command@1.2.0:
     resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
     engines: {node: '>=0.10.0'}
@@ -5952,6 +6089,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vite-plugin-commonjs@0.10.4:
@@ -6149,8 +6287,8 @@ packages:
     peerDependencies:
       eslint: '>=6.0.0'
 
-  vue-tsc@3.2.7:
-    resolution: {integrity: sha512-zc1tL3HoQni1zGTGrwBVRQb7rGP5SWdu/m4rGB6JcnAC5MT5LFZIxF7Y+EJEnt4hGF23d60rXH7gRjHGb5KQQQ==}
+  vue-tsc@3.2.6:
+    resolution: {integrity: sha512-gYW/kWI0XrwGzd0PKc7tVB/qpdeAkIZLNZb10/InizkQjHjnT8weZ/vBarZoj4kHKbUTZT/bAVgoOr8x4NsQ/Q==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
@@ -6210,6 +6348,10 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -6262,6 +6404,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
 
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
@@ -7309,10 +7455,128 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.2': {}
 
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/checkbox@4.3.2(@types/node@24.5.2)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.5.2)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.5.2
+
+  '@inquirer/confirm@5.1.21(@types/node@24.5.2)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.5.2)
+      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+    optionalDependencies:
+      '@types/node': 24.5.2
+
+  '@inquirer/core@10.3.2(@types/node@24.5.2)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.5.2
+
+  '@inquirer/editor@4.2.23(@types/node@24.5.2)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.5.2)
+      '@inquirer/external-editor': 1.0.3(@types/node@24.5.2)
+      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+    optionalDependencies:
+      '@types/node': 24.5.2
+
+  '@inquirer/expand@4.0.23(@types/node@24.5.2)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.5.2)
+      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.5.2
+
   '@inquirer/external-editor@1.0.3(@types/node@24.5.2)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.1
+    optionalDependencies:
+      '@types/node': 24.5.2
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/input@4.3.1(@types/node@24.5.2)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.5.2)
+      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+    optionalDependencies:
+      '@types/node': 24.5.2
+
+  '@inquirer/number@3.0.23(@types/node@24.5.2)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.5.2)
+      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+    optionalDependencies:
+      '@types/node': 24.5.2
+
+  '@inquirer/password@4.0.23(@types/node@24.5.2)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.5.2)
+      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+    optionalDependencies:
+      '@types/node': 24.5.2
+
+  '@inquirer/prompts@7.10.1(@types/node@24.5.2)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@24.5.2)
+      '@inquirer/confirm': 5.1.21(@types/node@24.5.2)
+      '@inquirer/editor': 4.2.23(@types/node@24.5.2)
+      '@inquirer/expand': 4.0.23(@types/node@24.5.2)
+      '@inquirer/input': 4.3.1(@types/node@24.5.2)
+      '@inquirer/number': 3.0.23(@types/node@24.5.2)
+      '@inquirer/password': 4.0.23(@types/node@24.5.2)
+      '@inquirer/rawlist': 4.1.11(@types/node@24.5.2)
+      '@inquirer/search': 3.2.2(@types/node@24.5.2)
+      '@inquirer/select': 4.4.2(@types/node@24.5.2)
+    optionalDependencies:
+      '@types/node': 24.5.2
+
+  '@inquirer/rawlist@4.1.11(@types/node@24.5.2)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.5.2)
+      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.5.2
+
+  '@inquirer/search@3.2.2(@types/node@24.5.2)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@24.5.2)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.5.2
+
+  '@inquirer/select@4.4.2(@types/node@24.5.2)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@24.5.2)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@24.5.2)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 24.5.2
+
+  '@inquirer/type@3.0.10(@types/node@24.5.2)':
     optionalDependencies:
       '@types/node': 24.5.2
 
@@ -7399,7 +7663,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       node-fetch: 2.7.0
       nopt: 8.1.0
-      semver: 7.6.3
+      semver: 7.8.4
       tar: 7.4.3
     transitivePeerDependencies:
       - encoding
@@ -7443,21 +7707,21 @@ snapshots:
 
   '@milaboratories/biowasm-tools@2.0.3': {}
 
-  '@milaboratories/computable@2.9.4':
+  '@milaboratories/computable@2.9.5':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/ts-helpers': 1.8.3
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
-  '@milaboratories/graph-maker@1.4.5(@milaboratories/pl-model-common@1.45.0)(@platforma-sdk/model@1.78.4)(@platforma-sdk/ui-vue@1.78.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/graph-maker@1.4.6(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.6(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.5
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.3(@milaboratories/pl-model-common@1.45.0)(@platforma-sdk/model@1.78.4)
-      '@platforma-sdk/model': 1.78.4
-      '@platforma-sdk/ui-vue': 1.78.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)
+      '@platforma-sdk/model': 1.79.6
+      '@platforma-sdk/ui-vue': 1.79.6(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       '@types/d3-hierarchy': 3.1.7
       '@types/d3-scale': 4.0.9
       '@vueuse/core': 13.4.0(vue@3.5.25(typescript@5.6.3))
@@ -7473,8 +7737,6 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
       - typescript
-
-  '@milaboratories/helpers@1.14.1': {}
 
   '@milaboratories/helpers@1.14.2': {}
 
@@ -7516,13 +7778,13 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/multi-sequence-alignment@1.47.15(@milaboratories/pl-model-common@1.45.0)(@platforma-sdk/model@1.78.4)(@platforma-sdk/ui-vue@1.78.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
+  '@milaboratories/multi-sequence-alignment@1.47.16(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.6(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.6.3)':
     dependencies:
       '@milaboratories/biowasm-tools': 2.0.3
       '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.3(@milaboratories/pl-model-common@1.45.0)(@platforma-sdk/model@1.78.4)
-      '@platforma-sdk/model': 1.78.4
-      '@platforma-sdk/ui-vue': 1.78.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
+      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)
+      '@platforma-sdk/model': 1.79.6
+      '@platforma-sdk/ui-vue': 1.79.6(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)
       vue: 3.5.25(typescript@5.6.3)
     transitivePeerDependencies:
       - '@milaboratories/pl-model-common'
@@ -7532,14 +7794,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@milaboratories/pf-driver@1.7.0(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-driver@1.7.10(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-node': 1.1.41
-      '@milaboratories/pframes-rs-wasm': 1.1.41(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.45.0)(@milaboratories/pl-model-middle-layer@1.29.0)
-      '@milaboratories/pl-model-common': 1.45.0
-      '@milaboratories/pl-model-middle-layer': 1.29.0
-      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/pframes-rs-node': 1.1.46
+      '@milaboratories/pframes-rs-wasm': 1.1.46(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.1)(@milaboratories/pl-model-middle-layer@1.30.6)
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.6
+      '@milaboratories/ts-helpers': 1.8.3
       es-toolkit: 1.39.10
       lru-cache: 11.2.2
     transitivePeerDependencies:
@@ -7547,58 +7809,60 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-plots@1.4.3(@milaboratories/pl-model-common@1.45.0)(@platforma-sdk/model@1.78.4)':
+  '@milaboratories/pf-plots@1.4.4(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.45.0
-      '@platforma-sdk/model': 1.78.4
+      '@milaboratories/pl-model-common': 1.46.1
+      '@platforma-sdk/model': 1.79.6
       canonicalize: 2.1.0
       lodash: 4.17.21
 
-  '@milaboratories/pf-spec-driver@1.4.3(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-spec-driver@1.4.12(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-wasm': 1.1.41(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.45.0)(@milaboratories/pl-model-middle-layer@1.29.0)
-      '@milaboratories/pl-model-common': 1.45.0
-      '@milaboratories/pl-model-middle-layer': 1.29.0
+      '@milaboratories/pframes-rs-wasm': 1.1.46(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.1)(@milaboratories/pl-model-middle-layer@1.30.6)
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.6
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
 
-  '@milaboratories/pframes-rs-node@1.1.41':
+  '@milaboratories/pframes-rs-node@1.1.46':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pframes-rs-serv': 1.1.41
-      '@milaboratories/pl-model-common': 1.43.0
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pframes-rs-serv': 1.1.46
+      '@milaboratories/pl-model-common': 1.46.1
       ulid: 3.0.2
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@milaboratories/pframes-rs-serv@1.1.41':
+  '@milaboratories/pframes-rs-serv@1.1.46':
     dependencies:
-      '@milaboratories/helpers': 1.14.1
-      '@milaboratories/pl-model-common': 1.43.0
-      '@milaboratories/pl-model-middle-layer': 1.27.0
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.4
       commander: 14.0.3
       selfsigned: 5.5.0
 
-  '@milaboratories/pframes-rs-wasip2@1.1.41': {}
+  '@milaboratories/pframes-rs-wasip2@1.1.44': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.41(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.45.0)(@milaboratories/pl-model-middle-layer@1.29.0)':
+  '@milaboratories/pframes-rs-wasip2@1.1.46': {}
+
+  '@milaboratories/pframes-rs-wasm@1.1.46(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.1)(@milaboratories/pl-model-middle-layer@1.30.6)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
-      '@milaboratories/pframes-rs-wasip2': 1.1.41
-      '@milaboratories/pl-model-common': 1.45.0
-      '@milaboratories/pl-model-middle-layer': 1.29.0
+      '@milaboratories/pframes-rs-wasip2': 1.1.46
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.6
 
-  '@milaboratories/pl-client@3.11.1':
+  '@milaboratories/pl-client@3.11.4':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.45.0
-      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/ts-helpers': 1.8.3
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -7611,19 +7875,19 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.1
 
-  '@milaboratories/pl-config@1.8.1':
+  '@milaboratories/pl-config@1.8.2':
     dependencies:
-      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/ts-helpers': 1.8.3
       upath: 2.0.1
       yaml: 2.8.1
 
-  '@milaboratories/pl-deployments@3.0.4':
+  '@milaboratories/pl-deployments@3.0.7':
     dependencies:
-      '@milaboratories/pl-config': 1.8.1
-      '@milaboratories/pl-healthcheck': 1.0.0
+      '@milaboratories/pl-config': 1.8.2
+      '@milaboratories/pl-healthcheck': 1.0.1
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.45.0
-      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/ts-helpers': 1.8.3
       decompress: 4.2.1
       ssh2: 1.16.0
       tar: 7.4.3
@@ -7632,15 +7896,15 @@ snapshots:
       yaml: 2.8.1
       zod: 3.25.76
 
-  '@milaboratories/pl-drivers@1.15.3':
+  '@milaboratories/pl-drivers@1.15.6':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@milaboratories/computable': 2.9.4
+      '@milaboratories/computable': 2.9.5
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-client': 3.11.1
-      '@milaboratories/pl-model-common': 1.45.0
-      '@milaboratories/pl-tree': 1.12.9
-      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/pl-client': 3.11.4
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-tree': 1.12.12
+      '@milaboratories/ts-helpers': 1.8.3
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/plugin': 2.11.1
       '@protobuf-ts/runtime': 2.11.1
@@ -7659,16 +7923,16 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.25.76
 
-  '@milaboratories/pl-errors@1.4.19':
+  '@milaboratories/pl-errors@1.4.22':
     dependencies:
-      '@milaboratories/pl-client': 3.11.1
-      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/pl-client': 3.11.4
+      '@milaboratories/ts-helpers': 1.8.3
       zod: 3.25.76
 
-  '@milaboratories/pl-healthcheck@1.0.0':
+  '@milaboratories/pl-healthcheck@1.0.1':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/ts-helpers': 1.8.3
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -7677,92 +7941,87 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.64.6(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pl-middle-layer@1.64.25(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
     dependencies:
-      '@milaboratories/computable': 2.9.4
+      '@milaboratories/computable': 2.9.5
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pf-driver': 1.7.0(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pf-spec-driver': 1.4.3(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pframes-rs-node': 1.1.41
-      '@milaboratories/pframes-rs-wasm': 1.1.41(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.45.0)(@milaboratories/pl-model-middle-layer@1.29.0)
-      '@milaboratories/pl-client': 3.11.1
-      '@milaboratories/pl-deployments': 3.0.4
-      '@milaboratories/pl-drivers': 1.15.3
-      '@milaboratories/pl-errors': 1.4.19
+      '@milaboratories/pf-driver': 1.7.10(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.4.12(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pframes-rs-node': 1.1.46
+      '@milaboratories/pframes-rs-wasm': 1.1.46(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.1)(@milaboratories/pl-model-middle-layer@1.30.6)
+      '@milaboratories/pl-client': 3.11.4
+      '@milaboratories/pl-deployments': 3.0.7
+      '@milaboratories/pl-drivers': 1.15.6
+      '@milaboratories/pl-errors': 1.4.22
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.4
-      '@milaboratories/pl-model-common': 1.45.0
-      '@milaboratories/pl-model-middle-layer': 1.29.0
-      '@milaboratories/pl-tree': 1.12.9
+      '@milaboratories/pl-model-backend': 1.4.7
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.6
+      '@milaboratories/pl-tree': 1.12.12
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.2
-      '@platforma-sdk/block-tools': 2.10.5
-      '@platforma-sdk/model': 1.78.4
-      '@platforma-sdk/workflow-tengo': 6.3.0
+      '@milaboratories/ts-helpers': 1.8.3
+      '@platforma-sdk/block-tools': 2.10.17(@types/node@24.5.2)
+      '@platforma-sdk/model': 1.79.6
+      '@platforma-sdk/workflow-tengo': 6.6.0
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.39.10
       lru-cache: 11.2.2
       quickjs-emscripten: 0.31.0
+      semver: 7.8.4
       undici: 7.16.0
       utility-types: 3.11.0
       yaml: 2.8.1
       zod: 3.25.76
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
+      - '@types/node'
       - aws-crt
       - encoding
       - supports-color
 
-  '@milaboratories/pl-model-backend@1.4.4':
+  '@milaboratories/pl-model-backend@1.4.7':
     dependencies:
-      '@milaboratories/pl-client': 3.11.1
+      '@milaboratories/pl-client': 3.11.4
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.43.0':
+  '@milaboratories/pl-model-common@1.46.1':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
       canonicalize: 2.1.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-common@1.45.0':
+  '@milaboratories/pl-model-middle-layer@1.30.4':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-error-like': 1.12.10
-      canonicalize: 2.1.0
-      zod: 3.25.76
-
-  '@milaboratories/pl-model-middle-layer@1.27.0':
-    dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.43.0
+      '@milaboratories/pl-model-common': 1.46.1
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.29.0':
+  '@milaboratories/pl-model-middle-layer@1.30.6':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.45.0
+      '@milaboratories/pl-model-common': 1.46.1
       es-toolkit: 1.39.10
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-tree@1.12.9':
+  '@milaboratories/pl-tree@1.12.12':
     dependencies:
-      '@milaboratories/computable': 2.9.4
-      '@milaboratories/pl-client': 3.11.1
-      '@milaboratories/pl-errors': 1.4.19
-      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/computable': 2.9.5
+      '@milaboratories/pl-client': 3.11.4
+      '@milaboratories/pl-errors': 1.4.22
+      '@milaboratories/ts-helpers': 1.8.3
       denque: 2.1.0
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/ptabler-expression-js@1.2.28':
+  '@milaboratories/ptabler-expression-js@1.2.30':
     dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.12
+      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.14
 
   '@milaboratories/resolve-helper@1.1.3': {}
 
@@ -7772,7 +8031,7 @@ snapshots:
 
   '@milaboratories/tengo-tester@1.6.4': {}
 
-  '@milaboratories/ts-builder@1.5.0(@types/node@24.5.2)(rollup@4.53.5)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.1)':
+  '@milaboratories/ts-builder@1.5.1(@types/node@24.5.2)(rollup@4.53.5)(vue@3.5.24(typescript@5.6.3))(yaml@2.8.1)':
     dependencies:
       '@milaboratories/ts-configs': 1.2.3
       '@vitejs/plugin-vue': 6.0.5(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))(vue@3.5.24(typescript@5.6.3))
@@ -7782,7 +8041,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.17
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.5.2)(rollup@4.53.5)
       typescript: 5.9.3
@@ -7791,7 +8050,7 @@ snapshots:
       vite-plugin-dts: 4.5.4(@types/node@24.5.2)(rollup@4.53.5)(typescript@5.9.3)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
       vite-plugin-externalize-deps: 0.10.0(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
       vite-plugin-lib-inject-css: 2.2.2(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
-      vue-tsc: 3.2.7(typescript@5.9.3)
+      vue-tsc: 3.2.6(typescript@5.9.3)
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@types/node'
@@ -7813,7 +8072,7 @@ snapshots:
       - vue
       - yaml
 
-  '@milaboratories/ts-builder@1.5.0(@types/node@24.5.2)(rollup@4.53.5)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.1)':
+  '@milaboratories/ts-builder@1.5.1(@types/node@24.5.2)(rollup@4.53.5)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.1)':
     dependencies:
       '@milaboratories/ts-configs': 1.2.3
       '@vitejs/plugin-vue': 6.0.5(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))(vue@3.5.25(typescript@5.6.3))
@@ -7823,7 +8082,7 @@ snapshots:
       oxlint: 1.63.0
       oxlint-plugin-eslint: 1.63.0
       rolldown: 1.0.0-rc.17
-      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3))
+      rolldown-plugin-dts: 0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3))
       rollup-plugin-copy: 3.5.0
       rollup-plugin-sourcemaps2: 0.5.4(@types/node@24.5.2)(rollup@4.53.5)
       typescript: 5.9.3
@@ -7832,7 +8091,7 @@ snapshots:
       vite-plugin-dts: 4.5.4(@types/node@24.5.2)(rollup@4.53.5)(typescript@5.9.3)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
       vite-plugin-externalize-deps: 0.10.0(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
       vite-plugin-lib-inject-css: 2.2.2(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
-      vue-tsc: 3.2.7(typescript@5.9.3)
+      vue-tsc: 3.2.6(typescript@5.9.3)
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@types/node'
@@ -7856,21 +8115,21 @@ snapshots:
 
   '@milaboratories/ts-configs@1.2.3': {}
 
-  '@milaboratories/ts-helpers-oclif@1.1.41':
+  '@milaboratories/ts-helpers-oclif@1.1.42':
     dependencies:
-      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/ts-helpers': 1.8.3
       '@oclif/core': 4.2.6
 
-  '@milaboratories/ts-helpers@1.8.2':
+  '@milaboratories/ts-helpers@1.8.3':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.14.22(typescript@5.6.3)':
+  '@milaboratories/uikit@2.15.7(typescript@5.6.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@platforma-sdk/model': 1.78.4
+      '@platforma-sdk/model': 1.79.6
       '@types/d3-array': 3.2.1
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -8174,11 +8433,11 @@ snapshots:
       '@platforma-open/milaboratories.runenv-python-3.12.10-rapids': 1.4.2
       '@platforma-open/milaboratories.runenv-python-3.12.10-sccoda': 1.3.3
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.12':
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.14':
     dependencies:
-      '@milaboratories/pl-model-common': 1.45.0
+      '@milaboratories/pl-model-common': 1.46.1
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.0': {}
+  '@platforma-open/milaboratories.software-ptabler@2.1.1': {}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2': {}
 
@@ -8186,29 +8445,33 @@ snapshots:
 
   '@platforma-open/milaboratories.software-small-binaries.hello-world@1.1.7': {}
 
+  '@platforma-open/milaboratories.software-small-binaries.line-counter@1.1.1': {}
+
   '@platforma-open/milaboratories.software-small-binaries.mnz-client@1.6.5': {}
 
   '@platforma-open/milaboratories.software-small-binaries.table-converter@1.3.5': {}
 
-  '@platforma-open/milaboratories.software-small-binaries@2.0.4':
+  '@platforma-open/milaboratories.software-small-binaries@2.1.1':
     dependencies:
       '@platforma-open/milaboratories.software-small-binaries.hello-world': 1.1.7
       '@platforma-open/milaboratories.software-small-binaries.hello-world-py': 1.0.10
+      '@platforma-open/milaboratories.software-small-binaries.line-counter': 1.1.1
       '@platforma-open/milaboratories.software-small-binaries.mnz-client': 1.6.5
       '@platforma-open/milaboratories.software-small-binaries.table-converter': 1.3.5
 
   '@platforma-open/soedinglab.software-mmseqs2@1.18.0': {}
 
-  '@platforma-sdk/block-tools@2.10.5':
+  '@platforma-sdk/block-tools@2.10.17(@types/node@24.5.2)':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
+      '@inquirer/prompts': 7.10.1(@types/node@24.5.2)
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.4
-      '@milaboratories/pl-model-common': 1.45.0
-      '@milaboratories/pl-model-middle-layer': 1.29.0
+      '@milaboratories/pl-model-backend': 1.4.7
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.6
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.2
-      '@milaboratories/ts-helpers-oclif': 1.1.41
+      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers-oclif': 1.1.42
       '@oclif/core': 4.2.6
       '@platforma-sdk/blocks-deps-updater': 2.2.0
       canonicalize: 2.1.0
@@ -8219,6 +8482,7 @@ snapshots:
       yaml: 2.8.1
       zod: 3.25.76
     transitivePeerDependencies:
+      - '@types/node'
       - aws-crt
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
@@ -8236,20 +8500,20 @@ snapshots:
       typescript: 5.6.3
       typescript-eslint: 8.24.0(eslint@9.39.2)(typescript@5.6.3)
 
-  '@platforma-sdk/model@1.78.4':
+  '@platforma-sdk/model@1.79.6':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/pl-model-common': 1.45.0
-      '@milaboratories/pl-model-middle-layer': 1.29.0
-      '@milaboratories/ptabler-expression-js': 1.2.28
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/pl-model-middle-layer': 1.30.6
+      '@milaboratories/ptabler-expression-js': 1.2.30
       canonicalize: 2.1.0
       es-toolkit: 1.39.10
       fast-json-patch: 3.1.1
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@platforma-sdk/package-builder@3.12.0':
+  '@platforma-sdk/package-builder@3.13.0':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@aws-sdk/lib-storage': 3.859.0(@aws-sdk/client-s3@3.859.0)
@@ -8265,23 +8529,23 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@platforma-sdk/tengo-builder@4.0.5':
+  '@platforma-sdk/tengo-builder@4.0.8':
     dependencies:
-      '@milaboratories/pl-model-backend': 1.4.4
+      '@milaboratories/pl-model-backend': 1.4.7
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
-      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/ts-helpers': 1.8.3
       '@oclif/core': 4.2.6
       winston: 3.17.0
 
-  '@platforma-sdk/test@1.78.4(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))':
+  '@platforma-sdk/test@1.79.7(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))':
     dependencies:
-      '@milaboratories/computable': 2.9.4
-      '@milaboratories/pl-client': 3.11.1
-      '@milaboratories/pl-middle-layer': 1.64.6(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-tree': 1.12.9
-      '@platforma-sdk/model': 1.78.4
-      '@vitest/coverage-istanbul': 4.1.5(vitest@4.1.5(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.5(vitest@4.0.8(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1)))(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1)))
+      '@milaboratories/computable': 2.9.5
+      '@milaboratories/pl-client': 3.11.4
+      '@milaboratories/pl-middle-layer': 1.64.25(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
+      '@milaboratories/pl-tree': 1.12.12
+      '@platforma-sdk/model': 1.79.6
+      '@vitest/coverage-istanbul': 4.1.5(vitest@4.1.5)
       vitest: 4.1.5(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.5(vitest@4.0.8(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1)))(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
@@ -8301,12 +8565,12 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.78.4(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
+  '@platforma-sdk/ui-vue@1.79.6(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.6.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.4.3(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-model-common': 1.45.0
-      '@milaboratories/uikit': 2.14.22(typescript@5.6.3)
-      '@platforma-sdk/model': 1.78.4
+      '@milaboratories/pf-spec-driver': 1.4.12(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-model-common': 1.46.1
+      '@milaboratories/uikit': 2.15.7(typescript@5.6.3)
+      '@platforma-sdk/model': 1.79.6
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.0
@@ -8337,13 +8601,13 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@6.3.0':
+  '@platforma-sdk/workflow-tengo@6.6.0':
     dependencies:
-      '@milaboratories/pframes-rs-wasip2': 1.1.41
+      '@milaboratories/pframes-rs-wasip2': 1.1.44
       '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 2.1.0
+      '@platforma-open/milaboratories.software-ptabler': 2.1.1
       '@platforma-open/milaboratories.software-ptexter': 1.2.2
-      '@platforma-open/milaboratories.software-small-binaries': 2.0.4
+      '@platforma-open/milaboratories.software-small-binaries': 2.1.1
 
   '@protobuf-ts/grpc-transport@2.11.1(@grpc/grpc-js@1.13.4)':
     dependencies:
@@ -11165,7 +11429,7 @@ snapshots:
       vite: 8.0.10(@types/node@24.5.2)(yaml@2.8.1)
       vue: 3.5.25(typescript@5.6.3)
 
-  '@vitest/coverage-istanbul@4.1.5(vitest@4.1.5(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.5(vitest@4.0.8(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1)))(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1)))':
+  '@vitest/coverage-istanbul@4.1.5(vitest@4.1.5)':
     dependencies:
       '@babel/core': 7.29.0
       '@istanbuljs/schema': 0.1.3
@@ -11351,7 +11615,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@vue/language-core@3.2.7':
+  '@vue/language-core@3.2.6':
     dependencies:
       '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.25
@@ -11737,6 +12001,8 @@ snapshots:
       escape-string-regexp: 4.0.0
 
   cli-spinners@2.9.2: {}
+
+  cli-width@4.1.0: {}
 
   cliui@8.0.1:
     dependencies:
@@ -12748,6 +13014,8 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
+  mute-stream@2.0.0: {}
+
   nan@2.22.0:
     optional: true
 
@@ -13109,7 +13377,7 @@ snapshots:
     dependencies:
       glob: 10.4.5
 
-  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.6.3)):
+  rolldown-plugin-dts@0.23.2(rolldown@1.0.0-rc.17)(typescript@5.9.3)(vue-tsc@3.2.6(typescript@5.6.3)):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
@@ -13124,7 +13392,7 @@ snapshots:
       rolldown: 1.0.0-rc.17
     optionalDependencies:
       typescript: 5.9.3
-      vue-tsc: 3.2.7(typescript@5.9.3)
+      vue-tsc: 3.2.6(typescript@5.9.3)
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -13224,6 +13492,8 @@ snapshots:
       lru-cache: 6.0.0
 
   semver@7.6.3: {}
+
+  semver@7.8.4: {}
 
   shebang-command@1.2.0:
     dependencies:
@@ -13665,7 +13935,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.5.2
-      '@vitest/coverage-istanbul': 4.1.5(vitest@4.1.5(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.5(vitest@4.0.8(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1)))(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1)))
+      '@vitest/coverage-istanbul': 4.1.5(vitest@4.1.5)
     transitivePeerDependencies:
       - msw
 
@@ -13686,10 +13956,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vue-tsc@3.2.7(typescript@5.9.3):
+  vue-tsc@3.2.6(typescript@5.9.3):
     dependencies:
       '@volar/typescript': 2.4.28
-      '@vue/language-core': 3.2.7
+      '@vue/language-core': 3.2.6
       typescript: 5.9.3
 
   vue@3.5.24(typescript@5.6.3):
@@ -13760,6 +14030,12 @@ snapshots:
 
   wordwrap@1.0.0: {}
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -13806,6 +14082,8 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors-cjs@2.1.3: {}
 
   zip-stream@6.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,22 +8,22 @@ packages:
 
 catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
-  '@milaboratories/ts-builder': 1.5.0
+  '@milaboratories/ts-builder': 1.5.1
   '@milaboratories/ts-configs': 1.2.3
-  '@platforma-sdk/workflow-tengo': 6.3.0
-  '@platforma-sdk/model': 1.78.4
-  '@platforma-sdk/ui-vue': 1.78.4
-  '@platforma-sdk/tengo-builder': 4.0.5
-  '@platforma-sdk/package-builder': 3.12.0
-  '@platforma-sdk/block-tools': 2.10.5
+  '@platforma-sdk/workflow-tengo': 6.6.0
+  '@platforma-sdk/model': 1.79.6
+  '@platforma-sdk/ui-vue': 1.79.6
+  '@platforma-sdk/tengo-builder': 4.0.8
+  '@platforma-sdk/package-builder': 3.13.0
+  '@platforma-sdk/block-tools': 2.10.17
   '@platforma-sdk/eslint-config': 1.2.0
-  '@platforma-sdk/test': 1.78.4
+  '@platforma-sdk/test': 1.79.7
   '@milaboratories/helpers': 1.14.2
   '@milaboratories/strings': 0.1.2
 
   # Block-specific dependencies
-  '@milaboratories/graph-maker': 1.4.5
-  '@milaboratories/multi-sequence-alignment': '1.47.15'
+  '@milaboratories/graph-maker': 1.4.6
+  '@milaboratories/multi-sequence-alignment': '1.47.16'
   '@milaboratories/software-pframes-conv': ^2.2.9
   '@platforma-open/milaboratories.runenv-python-3': ^1.7.3
   '@platforma-open/soedinglab.software-mmseqs2': 1.18.0

--- a/software/package.json
+++ b/software/package.json
@@ -54,6 +54,24 @@
           ]
         }
       },
+      "embedding-clustering": {
+        "binary": {
+          "artifact": {
+            "type": "python",
+            "registry": "platforma-open",
+            "environment": "@platforma-open/milaboratories.runenv-python-3:3.12.10",
+            "dependencies": {
+              "toolset": "pip",
+              "requirements": "requirements.txt"
+            },
+            "root": "./src"
+          },
+          "cmd": [
+            "python",
+            "{pkg}/embedding_clustering.py"
+          ]
+        }
+      },
       "empty-check": {
         "binary": {
           "artifact": {

--- a/software/src/embedding_clustering.py
+++ b/software/src/embedding_clustering.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Embedding-distance clustering for clonotype-clustering.
+
+Replaces the MMseqs2 step in embedding mode. Reads one per-clonotype embedding matrix,
+de-duplicates identical vectors, reduces with centered PCA (95% variance, capped), L2-normalizes,
+clusters with sklearn HDBSCAN (eom), picks each cluster's medoid representative, sends HDBSCAN noise
+to singleton clusters, and writes the files process_results.py consumes:
+
+  clusters.tsv          headerless (clusterId, clonotypeKey) -- both representative keys,
+                        clusterId = the cluster's medoid representative, one row per representative.
+  dedup_mapping.tsv     headered  (representativeKey, clonotypeKey) -- same format prepare_fasta.py
+                        writes; process_results.py joins it by column name to expand reps -> members.
+  centroid_distances.tsv  headered (representativeKey, distance) -- cosine distance to the cluster
+                        medoid in the reduced/normalized space; one row per representative,
+                        noise singletons at distance 0 (so the downstream expansion join is complete).
+
+The exact path runs on scikit-learn + numpy only.
+"""
+import warnings
+warnings.simplefilter("ignore", category=FutureWarning)  # match block convention (calculate_dim_reduction.py)
+
+import argparse
+import time
+
+import numpy as np
+from sklearn.cluster import HDBSCAN
+from sklearn.decomposition import PCA
+from sklearn.metrics import pairwise_distances
+
+
+def log(*a):
+    print(f"[{time.strftime('%H:%M:%S')}]", *a, flush=True)
+
+
+# --- Medoid helper (reproduces hdbscan.weighted_cluster_medoid exactly) ----------------
+# X must be L2-normalized so euclidean distance is the metric the clustering ran on. Returns the
+# GLOBAL row index of the representative (map it to the clonotype id). Validated 100% against contrib.
+
+def weighted_medoid(X, idx, weights=None):
+    """EXACT, O(m^2). Real-member medoid of the cluster whose member row-indices are `idx`:
+    the member minimizing the probability-weighted sum of euclidean distances to the rest.
+    weights: per-member membership strength (HDBSCAN probabilities_); None -> unweighted.
+    Returns a global row index."""
+    Xc = X[idx]
+    w = np.ones(len(idx)) if weights is None else np.asarray(weights)[idx]
+    D = pairwise_distances(Xc, metric="euclidean")   # m x m; same metric as the clustering
+    cost = (D * w).sum(axis=1)                        # cost[i] = sum_j w[j] * dist(i, j)
+    return int(idx[int(cost.argmin())])
+
+
+def approx_weighted_medoid(X, idx, weights=None):
+    """APPROXIMATE, O(m). Real member nearest the (weighted) mean direction -- for huge clusters,
+    avoids the m x m matrix. Same inputs/return as weighted_medoid."""
+    Xc = X[idx]
+    w = np.ones(len(idx)) if weights is None else np.asarray(weights)[idx]
+    c = (w[:, None] * Xc).sum(axis=0)        # weighted centroid (un-normalized)
+    n = np.linalg.norm(c)
+    if n == 0:                               # degenerate (all-zero) -> first member
+        return int(idx[0])
+    return int(idx[int((Xc @ (c / n)).argmax())])   # member with max cosine to centroid direction
+
+
+def cluster_medoids(X, labels, weights=None, exact_max=4000):
+    """Medoid (global row index) per non-noise cluster. EXACT for clusters with <= exact_max members
+    (the O(m^2) matrix is bounded: 4000 -> ~128 MB float64), APPROXIMATE O(m) above that. Cost scales
+    with per-CLUSTER size, so for huge N made of small clusters the exact path is already cheap."""
+    medoids = {}
+    for cid in np.unique(labels):
+        if cid == -1:                        # skip HDBSCAN noise
+            continue
+        idx = np.where(labels == cid)[0]
+        fn = weighted_medoid if len(idx) <= exact_max else approx_weighted_medoid
+        medoids[int(cid)] = fn(X, idx, weights)
+    return medoids
+
+
+# --- Recipe steps ---------------------------------------------------------------
+
+def centered_pca_95(X, cap=500):
+    """Centered PCA -> the number of components for 95% cumulative variance, capped at `cap`.
+    Uses svd_solver='full' (deterministic). Returns the reduced matrix and k."""
+    ncomp = min(cap, X.shape[0] - 1, X.shape[1])
+    if ncomp < 1:
+        return X.astype(np.float64), X.shape[1]
+    pca = PCA(n_components=ncomp, svd_solver="full").fit(X)
+    cum = np.cumsum(pca.explained_variance_ratio_)
+    k = min(int(np.searchsorted(cum, 0.95) + 1), ncomp)
+    return pca.transform(X)[:, :k], k
+
+
+def l2_normalize(X, eps=1e-12):
+    return (X / (np.linalg.norm(X, axis=1, keepdims=True) + eps)).astype(np.float64)
+
+
+def vector_dedup(X, keys):
+    """Collapse identical vectors (exact; bit-identical for same-model/same-sequence embeddings).
+    Returns (uniq, rep_keys, member_rep_keys): the unique-vector matrix, the representative key per
+    unique row (smallest clonotypeKey, deterministic), and the representative key for every input row."""
+    order = np.argsort(keys, kind="stable")              # lexicographic by key -> first occ = min key
+    Xs, ks = X[order], keys[order]
+    uniq, first, inv = np.unique(Xs, axis=0, return_index=True, return_inverse=True)
+    inv = inv.ravel()
+    rep_keys = ks[first]                                 # min key per unique vector
+    member_rep_keys = np.empty(len(keys), dtype=object)
+    member_rep_keys[order] = rep_keys[inv]               # representative for each original row
+    return uniq, rep_keys, member_rep_keys
+
+
+def run_clustering(X, keys, min_cluster_size=5, min_samples=5, pca_cap=500, exact_max=4000):
+    """Pure core (numpy/sklearn only, importable for tests).
+    X: (N, D) raw per-clonotype embedding matrix. keys: (N,) clonotype keys (object/str).
+    Returns a dict:
+      rep_keys           (M,)   representative key per unique vector
+      cluster_id         (M,)   clusterId for each representative (medoid repkey, or self if noise)
+      member_rep_keys    (N,)   representative key for every input clonotype (for dedup_mapping)
+      distance           (M,)   cosine distance of each representative to its cluster medoid (0 for noise)
+      stats              dict   N, n_unique, k_pca, n_clusters, noise_fraction, n_degenerate
+    """
+    N = X.shape[0]
+    uniq, rep_keys, member_rep_keys = vector_dedup(X, keys)
+    M = uniq.shape[0]
+
+    if M < max(2, min_cluster_size):
+        # Too few unique vectors to form a cluster: every representative is its own singleton.
+        return dict(rep_keys=rep_keys, cluster_id=rep_keys.copy(), member_rep_keys=member_rep_keys,
+                    distance=np.zeros(M), stats=dict(N=N, n_unique=M, k_pca=0, n_clusters=0,
+                                                     noise_fraction=1.0, n_degenerate=0))
+
+    Xr, k = centered_pca_95(uniq, cap=pca_cap)
+    Xn = l2_normalize(Xr)
+
+    # Degenerate (near-zero post-PCA norm) vectors cannot be normalized into a meaningful direction;
+    # exclude them from HDBSCAN (they become singletons) rather than feed a NaN that propagates.
+    pre_norm = np.linalg.norm(Xr, axis=1)
+    valid = pre_norm > 1e-8
+    n_degenerate = int((~valid).sum())
+    if n_degenerate:
+        log(f"WARNING: {n_degenerate} representative vector(s) near-zero norm post-PCA -> excluded as singletons")
+
+    labels = np.full(M, -1, dtype=np.int64)
+    probs = np.zeros(M)
+    if valid.sum() >= min_cluster_size:
+        clu = HDBSCAN(min_cluster_size=min_cluster_size, min_samples=min_samples,
+                      metric="euclidean", algorithm="ball_tree",
+                      cluster_selection_method="eom", n_jobs=-1).fit(Xn[valid])
+        labels[valid] = clu.labels_
+        probs[valid] = clu.probabilities_
+
+    medoids = cluster_medoids(Xn, labels, weights=probs, exact_max=exact_max)   # {cid: row index}
+
+    cluster_id = rep_keys.copy()          # default = self (covers noise singletons)
+    distance = np.zeros(M)
+    for cid, mrow in medoids.items():
+        members = np.where(labels == cid)[0]
+        cluster_id[members] = rep_keys[mrow]
+        # cosine distance to the medoid in the normalized space (unit vectors -> 1 - dot)
+        distance[members] = 1.0 - (Xn[members] @ Xn[mrow])
+
+    n_clusters = len(medoids)
+    noise_fraction = float((labels == -1).mean())
+    return dict(rep_keys=rep_keys, cluster_id=cluster_id, member_rep_keys=member_rep_keys,
+                distance=distance,
+                stats=dict(N=N, n_unique=M, k_pca=k, n_clusters=n_clusters,
+                           noise_fraction=noise_fraction, n_degenerate=n_degenerate))
+
+
+# --- I/O ----------------------------------------------------------------------------------------
+
+def load_matrix(path, key_col, dim_col, value_col):
+    """Read the long-format embedding matrix (parquet) -> (X, keys).
+    Rows are clonotypes (sorted by key, canonical order); each row is the value vector in
+    ascending embeddingDim order. Sorting by [key, dim] groups each clonotype's D values contiguously
+    in numeric dim order (not the lexicographic column-name order a pivot would impose), so a single
+    reshape(N, D) recovers the matrix without materializing it through Python lists (fast at scale)."""
+    import polars as pl
+    df = pl.read_parquet(path).select([key_col, dim_col, value_col]).sort([key_col, dim_col])
+    if df.height == 0:
+        return np.empty((0, 0), dtype=np.float64), np.array([], dtype=object)
+    keys = df.get_column(key_col).unique(maintain_order=True).to_list()   # ascending, first-occurrence
+    n = len(keys)
+    if df.height % n != 0:
+        raise ValueError(f"ragged embedding matrix: {df.height} rows for {n} clonotypes "
+                         f"(not a multiple) -- a clonotype is missing or has extra dimensions")
+    D = df.height // n
+    X = df.get_column(value_col).to_numpy().reshape(n, D).astype(np.float64)
+    return X, np.asarray(keys, dtype=object)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Embedding-distance clustering (HDBSCAN on ESM-2 vectors)")
+    ap.add_argument("--matrix", default="embedding.parquet", help="long-format embedding matrix (parquet)")
+    ap.add_argument("--key-col", default="clonotypeKey", help="clonotype-key column name in the matrix")
+    ap.add_argument("--dim-col", default="embeddingDim", help="embedding-dimension column name")
+    ap.add_argument("--value-col", default="value", help="embedding-value column name")
+    ap.add_argument("--min-cluster-size", type=int, default=5)
+    ap.add_argument("--min-samples", type=int, default=5)
+    ap.add_argument("--pca-cap", type=int, default=500)
+    args = ap.parse_args()
+
+    log(f"loading matrix {args.matrix} ...")
+    X, keys = load_matrix(args.matrix, args.key_col, args.dim_col, args.value_col)
+    log(f"loaded {X.shape[0]} clonotypes x {X.shape[1]} dims")
+
+    res = run_clustering(X, keys, min_cluster_size=args.min_cluster_size,
+                         min_samples=args.min_samples, pca_cap=args.pca_cap)
+    s = res["stats"]
+    log(f"unique vectors={s['n_unique']} (deduped from {s['N']}), PCA k={s['k_pca']}, "
+        f"clusters={s['n_clusters']}, noise={s['noise_fraction']:.1%}, degenerate={s['n_degenerate']}")
+
+    write_outputs(res, keys)
+    log("wrote clusters.tsv, dedup_mapping.tsv, centroid_distances.tsv")
+
+
+def write_outputs(res, keys):
+    """Write the three files process_results.py consumes."""
+    import polars as pl
+    rep = [str(k) for k in res["rep_keys"]]
+    # clusters.tsv -- HEADERLESS (clusterId, clonotypeKey): clusterId = medoid repkey (or self if
+    # noise), clonotypeKey = this representative's key. One row per representative.
+    pl.DataFrame({"clusterId": [str(c) for c in res["cluster_id"]], "clonotypeKey": rep}) \
+        .write_csv("clusters.tsv", separator="\t", include_header=False)
+    # dedup_mapping.tsv -- HEADERED (representativeKey, clonotypeKey), one row per original clonotype;
+    # same format prepare_fasta.py writes, so process_results.py expands rep -> members unchanged.
+    pl.DataFrame({"representativeKey": [str(k) for k in res["member_rep_keys"]],
+                  "clonotypeKey": [str(k) for k in keys]}) \
+        .write_csv("dedup_mapping.tsv", separator="\t", include_header=True)
+    # centroid_distances.tsv -- HEADERED (representativeKey, distance); one row per representative
+    # incl. noise singletons (distance 0) so the downstream expansion join is complete.
+    pl.DataFrame({"representativeKey": rep, "distance": res["distance"]}) \
+        .write_csv("centroid_distances.tsv", separator="\t", include_header=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/software/src/emptyCheck.py
+++ b/software/src/emptyCheck.py
@@ -15,12 +15,16 @@ def main():
                         help='Directory to save output files (default: current directory)')
     args = parser.parse_args()
 
-    # Open input file
-    df_input = pd.read_csv(args.input, sep=args.input_separator, dtype=str)
+    # Open input file. Embedding mode passes a Parquet matrix (separator is irrelevant there); sequence
+    # mode passes a TSV. Detect by extension so the same emptiness check serves both.
+    if args.input.lower().endswith('.parquet'):
+        import polars as pl
+        is_empty = pl.read_parquet(args.input).height == 0
+    else:
+        is_empty = pd.read_csv(args.input, sep=args.input_separator, dtype=str).empty
 
     # Check if input table is empty
-    fileContent = "empty"
-    if df_input.empty:
+    if is_empty:
         print("Input table is empty.")
         fileContent = "empty"
     else:

--- a/software/src/process_results.py
+++ b/software/src/process_results.py
@@ -8,6 +8,8 @@ parser.add_argument('--trim-end', type=int, default=0, help='Number of amino aci
 parser.add_argument('--per-chain-trim', action='store_true', help='Apply trimming to each chain before computing distances and summaries')
 parser.add_argument('--min-seq-id', type=float, default=1.0, help='Minimum sequence identity threshold (0-1) used by mmseqs2. Used for singleton reassignment post-processing.')
 parser.add_argument('--high-precision', action='store_true', help='Enable high-precision post-processing (singleton reassignment). Should match the high-precision mmseqs2 mode.')
+parser.add_argument('--distances', default=None, help='Embedding mode: precomputed cosine distances TSV (representativeKey, distance). When set, used instead of sequence Levenshtein.')
+parser.add_argument('--no-strip-prefix', action='store_true', help='Embedding mode: keys carry no "s-" prefix (prepare_fasta adds it for mmseqs); skip the strip.')
 args = parser.parse_args()
 
 trim_start = args.trim_start
@@ -90,10 +92,11 @@ clusters = pl.read_csv(clustersTsv, separator="\t", has_header=False,
 # Remove the "s-" prefix from clusterId and clonotypeKey. This prefix is added
 # during FASTA preparation for mmseqs and needs to be removed to match keys
 # in other tables like cloneTable.
-clusters = clusters.with_columns(
-    pl.col("clusterId").str.strip_prefix("s-"),
-    pl.col("clonotypeKey").str.strip_prefix("s-")
-)
+if not args.no_strip_prefix:
+    clusters = clusters.with_columns(
+        pl.col("clusterId").str.strip_prefix("s-"),
+        pl.col("clonotypeKey").str.strip_prefix("s-")
+    )
 
 def reassign_singletons(clusters: pl.DataFrame, cloneTable: pl.DataFrame,
                         min_seq_id: float) -> pl.DataFrame:
@@ -228,6 +231,17 @@ else:
 # each representative back to all original clonotypeKeys that share its sequence.
 dedup_mapping = pl.read_csv(dedupMappingTsv, separator="\t")
 # dedup_mapping has columns: representativeKey, clonotypeKey
+
+if args.distances:
+    # Embedding mode: clonotypes absent from the embedding matrix (e.g. sparse Fv/scFv coverage -- a
+    # clonotype without a complete chain pair) never reach clustering, so they carry no cluster and are
+    # naturally excluded from every output below (all of which derive from `clusters`). Report the drop
+    # count for the run log.
+    embedded_keys = set(dedup_mapping.get_column("clonotypeKey").to_list())
+    n_excluded = cloneTable.filter(~pl.col("clonotypeKey").is_in(embedded_keys)).height
+    if n_excluded:
+        print(f"Embedding mode: {n_excluded} clonotype(s) excluded from clustering -- no embedding "
+              f"vector in the selected column (e.g. sparse Fv/scFv coverage).")
 
 num_representatives = clusters.select(pl.col("clonotypeKey").n_unique()).item()
 clusters = clusters.rename({"clonotypeKey": "representativeKey"}).join(
@@ -414,7 +428,18 @@ distance_df = distance_df_base.join(
 )
 
 
-if not sequence_cols:
+if args.distances:
+    # Embedding mode: use precomputed cosine distances to the cluster medoid (one row per
+    # representativeKey, incl. noise singletons at 0), expanded to all clonotypes via dedup_mapping.
+    # No Levenshtein, and NO 1.0 cap -- cosine distance ranges 0-2.
+    centroid_distances = pl.read_csv(args.distances, separator="\t")  # headered: representativeKey, distance
+    member_dist = dedup_mapping.join(
+        centroid_distances, on="representativeKey", how="inner"
+    ).select(["clonotypeKey", "distance"])
+    distance_df = distance_df.join(member_dist, on="clonotypeKey", how="left").with_columns(
+        pl.col("distance").fill_null(0.0).alias("distanceToCentroid")
+    ).drop("distance")
+elif not sequence_cols:
     print("No sequence columns found. Setting distanceToCentroid to 0.0 for all entries.")
     distance_df = distance_df.with_columns(
         pl.lit(0.0, dtype=pl.Float64).alias("distanceToCentroid"),

--- a/software/src/requirements.txt
+++ b/software/src/requirements.txt
@@ -1,3 +1,5 @@
 pandas==2.2.3
 polars-lts-cpu==1.33.1
 polars-ds-lts-cpu==0.10.2
+scikit-learn==1.6.1
+numpy==2.2.6

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,7 @@
     },
     "build": {
       "inputs": ["$TURBO_DEFAULT$"],
-      "env": ["PL_PKG_DEV", "PL_DOCKER_REGISTRY_PUSH_TO"],
+      "env": ["PL_PKG_DEV", "PL_DOCKER_BUILD", "PL_DOCKER_AUTOPUSH", "PL_DOCKER_REGISTRY", "PL_DOCKER_REGISTRY_PUSH_TO"],
       "outputs": ["./dist/**", "./block-pack/**", "./pkg-*.tgz"],
       "dependsOn": ["type-check", "lint", "^build"]
     },

--- a/ui/src/app.ts
+++ b/ui/src/app.ts
@@ -27,7 +27,26 @@ export const useApp = sdkPlugin.useApp;
 type AppModel = ReturnType<typeof useApp>['model'];
 
 function syncDefaultBlockLabel(model: AppModel) {
+  // Resolve the human-readable column labels from the result pool (which the pure formatter can't do) and
+  // hand them to getDefaultBlockLabel, which owns all label-format logic. The method branch here is only
+  // about WHICH inputs to gather; it must run in the reactive effect (not only on the picker gesture)
+  // because the embedding-mode auto-derive writes sequencesRef, which would otherwise re-trigger this
+  // effect and recompute a sequence-mode label.
   watchEffect(() => {
+    if (model.data.clusteringMethod === 'embedding') {
+      const ref = model.data.embeddingRef;
+      const embeddingLabel = ref
+        ? model.outputs.embeddingOptions
+          ?.find((o) => o.ref.blockId === ref.blockId && o.ref.name === ref.name)
+          ?.label ?? 'Embedding'
+        : 'Embedding';
+      model.data.defaultBlockLabel = getDefaultBlockLabel({
+        clusteringMethod: 'embedding',
+        embeddingLabel,
+        minClusterSize: model.data.minClusterSize,
+      });
+      return;
+    }
     const sequenceLabels = model.data.sequencesRef
       .map((r) => {
         const label = model.outputs.sequenceOptions
@@ -36,6 +55,7 @@ function syncDefaultBlockLabel(model: AppModel) {
         return label?.replace('InFrame', '') ?? '';
       });
     model.data.defaultBlockLabel = getDefaultBlockLabel({
+      clusteringMethod: 'sequence',
       sequenceLabels,
       similarityType: model.data.similarityType,
       identity: model.data.identity,

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -60,6 +60,10 @@ const onRowDoubleClicked = reactive((key?: PTableKey) => {
 
 function setInput(inputRef?: PlRef) {
   app.model.data.datasetRef = inputRef;
+  // Embedding refs are anchor-bound and not portable across datasets: reset to sequence mode and
+  // clear the embedding selection on any dataset change.
+  app.model.data.clusteringMethod = 'sequence';
+  app.model.data.embeddingRef = undefined;
 }
 
 const tableSettings = usePlDataTableSettingsV2({
@@ -111,6 +115,89 @@ const hasCDR3Sequences = computed(() => {
     return columnName.includes('cdr3') || columnName.includes('cdr-3');
   });
 });
+
+// --- Embedding-distance clustering ---
+const clusteringMethodOptions = [
+  { label: 'Sequences', value: 'sequence' },
+  { label: 'Embeddings', value: 'embedding' },
+] as const;
+
+// Embedding mode is reachable only when an embedding column is discoverable on the dataset.
+const embeddingAvailable = computed(() => (app.model.outputs.embeddingOptions?.length ?? 0) > 0);
+// Effective mode: fall back to sequence rendering if embeddings aren't available, even if the stored
+// method is 'embedding' (e.g. embeddings vanished without a dataset change).
+const effectiveMethod = computed(() =>
+  (app.model.data.clusteringMethod === 'embedding' && embeddingAvailable.value) ? 'embedding' : 'sequence',
+);
+
+// Safeguard: if the embedding column's producer becomes undiscoverable while embedding mode is stored
+// (e.g. the upstream Sequence Embeddings block is removed without a dataset change), fall back to
+// sequence mode so the args projection and the UI agree.
+watch(embeddingAvailable, (available) => {
+  if (!available && app.model.data.clusteringMethod === 'embedding') {
+    app.model.data.clusteringMethod = 'sequence';
+    app.model.data.embeddingRef = undefined;
+  }
+});
+
+// Auto-derive the source sequence column(s) for the picked embedding column, so the user need
+// not pick a sequence column in embedding mode.
+function deriveSourceSeqRefs(embeddingRef: PlRef): SUniversalPColumnId[] {
+  const embOpts = app.model.outputs.embeddingOptions;
+  const seqOpts = app.model.outputs.sequenceOptions;
+  if (!embOpts || !seqOpts) return [];
+  const embFeature = embOpts.find(
+    (o) => o.ref.blockId === embeddingRef.blockId && o.ref.name === embeddingRef.name,
+  )?.feature;
+  if (!embFeature) return [];
+  const domainOf = (id: string): Record<string, string> => {
+    try {
+      return (JSON.parse(id)?.domain ?? {}) as Record<string, string>;
+    } catch {
+      return {};
+    }
+  };
+  const nameOf = (id: string): string | undefined => {
+    try {
+      return JSON.parse(id)?.name as string | undefined;
+    } catch {
+      return undefined;
+    }
+  };
+  const norm = (f: string | undefined) => (f ?? '').replace(/InFrame$/i, '');
+  // Source sequences are amino acid (ESM-2). Embedding mode forces sequenceType='aminoacid', but guard
+  // explicitly so a stale nucleotide selection yields no match rather than a wrong (nucleotide) one.
+  const isAa = (id: string) => domainOf(id)['pl7.app/alphabet'] === 'aminoacid';
+  const seqFeature = (id: string) => {
+    const d = domainOf(id);
+    return d['pl7.app/vdj/feature'] ?? d['pl7.app/feature'];
+  };
+  // Fv = VH+VL VDJRegion concatenation -> both chains' VDJRegion source columns.
+  if (embFeature === 'Fv') {
+    return seqOpts.filter((o) => isAa(o.value) && norm(seqFeature(o.value)) === 'VDJRegion').map((o) => o.value);
+  }
+  // scFv = the single-construct sequence column.
+  if (embFeature === 'scFv') {
+    return seqOpts.filter((o) => isAa(o.value) && nameOf(o.value) === 'pl7.app/vdj/scFv-sequence').map((o) => o.value);
+  }
+  // CDR3 / VDJRegion / peptide: match on the InFrame-normalized feature.
+  const target = norm(embFeature);
+  return seqOpts.filter((o) => isAa(o.value) && norm(seqFeature(o.value)) === target).map((o) => o.value);
+}
+
+// Method toggle gesture (V3 gesture-driven write, NOT a watcher). ESM-2 embeddings are amino-acid
+// based, so embedding mode forces sequenceType='aminoacid'
+function onMethodChange(method: 'sequence' | 'embedding') {
+  app.model.data.clusteringMethod = method;
+  if (method === 'embedding') app.model.data.sequenceType = 'aminoacid';
+}
+
+// On embedding-column pick: store the ref and auto-derive the source sequence column(s) for the
+// centroid/MSA display.
+function onEmbeddingRefChange(ref?: PlRef) {
+  app.model.data.embeddingRef = ref;
+  app.model.data.sequencesRef = ref ? deriveSourceSeqRefs(ref) : [];
+}
 
 // Auto-suggest BLOSUM matrix when the user changes selected sequences.
 // Wired to the dropdown's @update:model-value — must NOT be a `watch` on
@@ -193,13 +280,25 @@ const clusterAxis = computed<AxisId>(() => {
         required
         @update:model-value="setInput"
       />
-      <PlBtnGroup
-        v-model="app.model.data.sequenceType"
-        label="Sequence Type"
-        :options="sequenceType"
-        compact
-      />
+      <div style="display: flex; flex-direction: column; gap: 12px;">
+        <PlBtnGroup
+          v-if="embeddingAvailable"
+          :model-value="app.model.data.clusteringMethod"
+          label="Clustering mode"
+          :options="clusteringMethodOptions"
+          compact
+          @update:model-value="onMethodChange"
+        />
+        <PlBtnGroup
+          v-if="effectiveMethod === 'sequence'"
+          v-model="app.model.data.sequenceType"
+          label="Sequence Type"
+          :options="sequenceType"
+          compact
+        />
+      </div>
       <PlDropdownMulti
+        v-if="effectiveMethod === 'sequence'"
         :model-value="app.model.data.sequencesRef"
         :options="app.model.outputs.sequenceOptions"
         label="Sequence Columns to Cluster"
@@ -208,39 +307,52 @@ const clusterAxis = computed<AxisId>(() => {
         @update:model-value="onSequencesRefChange"
       />
 
-      <PlDropdown
-        v-model="app.model.data.similarityType"
-        :options="similarityTypeOptions"
-        label="Alignment Score"
-      >
-        <template #tooltip>
-          Select the similarity metric used for clustering. BLOSUM matrices score biochemical similarity between amino acids — lower numbers (e.g. BLOSUM40) tolerate more substitutions and suit more divergent sequences, higher numbers (e.g. BLOSUM80) penalize substitutions more strongly and suit highly conserved sequences such as antibody framework regions. BLOSUM62 is a balanced default and works well for CDRs and many peptide sets. For very short peptides (≤8 aa), Exact Match — which counts only identical residues — might be a safer choice.
-        </template>
-      </PlDropdown>
+      <template v-if="effectiveMethod === 'embedding'">
+        <PlDropdownRef
+          :model-value="app.model.data.embeddingRef"
+          :options="app.model.outputs.embeddingOptions"
+          label="Embedding Column to Cluster"
+          required
+          :disabled="app.model.data.datasetRef === undefined"
+          @update:model-value="onEmbeddingRefChange"
+        />
+      </template>
 
-      <PlNumberField
-        v-model="app.model.data.identity"
-        label="Minimal Identity"
-        :minValue="0.1"
-        :step="0.1"
-        :maxValue="1.0"
-      >
-        <template #tooltip>
-          Sets the lowest percentage of identical residues required for sequences to be considered for the same cluster.
-        </template>
-      </PlNumberField>
+      <template v-if="effectiveMethod === 'sequence'">
+        <PlDropdown
+          v-model="app.model.data.similarityType"
+          :options="similarityTypeOptions"
+          label="Alignment Score"
+        >
+          <template #tooltip>
+            Select the similarity metric used for clustering. BLOSUM matrices score biochemical similarity between amino acids — lower numbers (e.g. BLOSUM40) tolerate more substitutions and suit more divergent sequences, higher numbers (e.g. BLOSUM80) penalize substitutions more strongly and suit highly conserved sequences such as antibody framework regions. BLOSUM62 is a balanced default and works well for CDRs and many peptide sets. For very short peptides (≤8 aa), Exact Match — which counts only identical residues — might be a safer choice.
+          </template>
+        </PlDropdown>
 
-      <PlNumberField
-        v-model="app.model.data.coverageThreshold"
-        label="Coverage Threshold"
-        :minValue="0.1"
-        :step="0.1"
-        :maxValue="1.0"
-      >
-        <template #tooltip>
-          Sets the lowest percentage of sequence length that must be covered for sequences to be considered for the same cluster.
-        </template>
-      </PlNumberField>
+        <PlNumberField
+          v-model="app.model.data.identity"
+          label="Minimal Identity"
+          :minValue="0.1"
+          :step="0.1"
+          :maxValue="1.0"
+        >
+          <template #tooltip>
+            Sets the lowest percentage of identical residues required for sequences to be considered for the same cluster.
+          </template>
+        </PlNumberField>
+
+        <PlNumberField
+          v-model="app.model.data.coverageThreshold"
+          label="Coverage Threshold"
+          :minValue="0.1"
+          :step="0.1"
+          :maxValue="1.0"
+        >
+          <template #tooltip>
+            Sets the lowest percentage of sequence length that must be covered for sequences to be considered for the same cluster.
+          </template>
+        </PlNumberField>
+      </template>
       <PlAlert v-if="app.model.outputs.inputState" type="warn" style="margin-top: 1rem">
         {{
           'Error: The input dataset you have selected is empty. \
@@ -248,7 +360,8 @@ const clusterAxis = computed<AxisId>(() => {
         }}
       </PlAlert>
       <PlAlert
-        v-if="app.model.outputs.modality === 'peptide'
+        v-if="effectiveMethod === 'sequence'
+          && app.model.outputs.modality === 'peptide'
           && app.model.outputs.minPeptideLength !== undefined
           && app.model.outputs.minPeptideLength < 5"
         type="warn"
@@ -262,49 +375,63 @@ const clusterAxis = computed<AxisId>(() => {
       </PlAlert>
 
       <PlAccordionSection :label="strings.titles.advancedSettings">
-        <PlDropdown
-          v-model="app.model.data.clusteringTool"
-          :options="clusteringToolOptions"
-          label="Clustering Algorithm"
-        >
-          <template #tooltip>
-            <b>Easy Cluster</b> — standard MMseqs2 cascaded clustering. Accurate for all dataset sizes.<br/>
-            <b>Easy Linclust</b> — linear-time clustering algorithm. Much faster for large datasets but may produce less precise clusters.
+        <template v-if="effectiveMethod === 'embedding'">
+          <PlNumberField
+            v-model="app.model.data.minClusterSize"
+            label="Min cluster size"
+            :minValue="2"
+            :step="1"
+          >
+            <template #tooltip>
+              HDBSCAN minimum cluster size — the smallest group of clonotypes that forms a cluster. Smaller finds more, smaller clusters. Default 5.
+            </template>
+          </PlNumberField>
+        </template>
+        <template v-if="effectiveMethod === 'sequence'">
+          <PlDropdown
+            v-model="app.model.data.clusteringTool"
+            :options="clusteringToolOptions"
+            label="Clustering Algorithm"
+          >
+            <template #tooltip>
+              <b>Easy Cluster</b> — standard MMseqs2 cascaded clustering. Accurate for all dataset sizes.<br/>
+              <b>Easy Linclust</b> — linear-time clustering algorithm. Much faster for large datasets but may produce less precise clusters.
+            </template>
+          </PlDropdown>
+
+          <PlCheckbox v-model="app.model.data.highPrecision" :disabled="app.model.data.clusteringTool === 'easy-linclust'">
+            High precision mode
+            <PlTooltip class="info" position="top">
+              <template #tooltip>Uses high-sensitivity MMseqs2 settings optimized for short sequences (e.g. a single CDR or a short peptide). Disable for longer sequences (e.g. full VDJ region or multiple concatenated sequences) as it may significantly increase computation time and memory usage. Only available with easy-cluster.</template>
+            </PlTooltip>
+          </PlCheckbox>
+
+          <template v-if="hasCDR3Sequences">
+            <PlSectionSeparator>Trimming options</PlSectionSeparator>
+            <PlNumberField
+              v-model="app.model.data.trimStart"
+              label="Trim from start (amino acids)"
+              :minValue="0"
+              :step="1"
+              :maxValue="100"
+            >
+              <template #tooltip>
+                Number of amino acids to remove from the beginning of each CDR3 sequence before clustering.
+              </template>
+            </PlNumberField>
+
+            <PlNumberField
+              v-model="app.model.data.trimEnd"
+              label="Trim from end (amino acids)"
+              :minValue="0"
+              :step="1"
+              :maxValue="100"
+            >
+              <template #tooltip>
+                Number of amino acids to remove from the end of each CDR3 sequence before clustering.
+              </template>
+            </PlNumberField>
           </template>
-        </PlDropdown>
-
-        <PlCheckbox v-model="app.model.data.highPrecision" :disabled="app.model.data.clusteringTool === 'easy-linclust'">
-          High precision mode
-          <PlTooltip class="info" position="top">
-            <template #tooltip>Uses high-sensitivity MMseqs2 settings optimized for short sequences (e.g. a single CDR or a short peptide). Disable for longer sequences (e.g. full VDJ region or multiple concatenated sequences) as it may significantly increase computation time and memory usage. Only available with easy-cluster.</template>
-          </PlTooltip>
-        </PlCheckbox>
-
-        <template v-if="hasCDR3Sequences">
-          <PlSectionSeparator>Trimming options</PlSectionSeparator>
-          <PlNumberField
-            v-model="app.model.data.trimStart"
-            label="Trim from start (amino acids)"
-            :minValue="0"
-            :step="1"
-            :maxValue="100"
-          >
-            <template #tooltip>
-              Number of amino acids to remove from the beginning of each CDR3 sequence before clustering.
-            </template>
-          </PlNumberField>
-
-          <PlNumberField
-            v-model="app.model.data.trimEnd"
-            label="Trim from end (amino acids)"
-            :minValue="0"
-            :step="1"
-            :maxValue="100"
-          >
-            <template #tooltip>
-              Number of amino acids to remove from the end of each CDR3 sequence before clustering.
-            </template>
-          </PlNumberField>
         </template>
 
         <PlSectionSeparator>Resource Allocation</PlSectionSeparator>
@@ -351,7 +478,7 @@ const clusterAxis = computed<AxisId>(() => {
   </PlSlideModal>
   <!-- Slide window with MMseqs2 log -->
   <PlSlideModal v-model="mmseqsLogOpen" width="80%">
-    <template #title>MMseqs2 Log</template>
+    <template #title>{{ app.model.data.clusteringMethod === 'embedding' ? 'Clustering Log' : 'MMseqs2 Log' }}</template>
     <PlLogView :log-handle="app.model.outputs.mmseqsOutput" />
   </PlSlideModal>
 </template>

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -288,7 +288,11 @@ const clusterAxis = computed<AxisId>(() => {
           :options="clusteringMethodOptions"
           compact
           @update:model-value="onMethodChange"
-        />
+        >
+          <template #tooltip>
+            Group clonotypes by amino-acid similarity (Sequences, MMseqs2) or by distance in a learned embedding space (Embeddings, HDBSCAN).
+          </template>
+        </PlBtnGroup>
         <PlBtnGroup
           v-if="effectiveMethod === 'sequence'"
           v-model="app.model.data.sequenceType"
@@ -301,7 +305,7 @@ const clusterAxis = computed<AxisId>(() => {
         v-if="effectiveMethod === 'sequence'"
         :model-value="app.model.data.sequencesRef"
         :options="app.model.outputs.sequenceOptions"
-        label="Sequence Columns to Cluster"
+        label="Sequences to Cluster"
         required
         :disabled="app.model.data.datasetRef === undefined"
         @update:model-value="onSequencesRefChange"
@@ -311,7 +315,7 @@ const clusterAxis = computed<AxisId>(() => {
         <PlDropdownRef
           :model-value="app.model.data.embeddingRef"
           :options="app.model.outputs.embeddingOptions"
-          label="Embedding Column to Cluster"
+          label="Embedding to Cluster"
           required
           :disabled="app.model.data.datasetRef === undefined"
           @update:model-value="onEmbeddingRefChange"

--- a/workflow/src/embedding-clustering.tpl.tengo
+++ b/workflow/src/embedding-clustering.tpl.tengo
@@ -1,0 +1,168 @@
+// Embedding-distance clustering path. Sibling to clustering.tpl.tengo
+// (the MMseqs2 path, left untouched). main.tpl.tengo dispatches here when clusteringMethod="embedding".
+// Honors the SAME output-file contract as clustering.tpl so main's emit/import code is method-agnostic.
+self := import("@platforma-sdk/workflow-tengo:tpl")
+exec := import("@platforma-sdk/workflow-tengo:exec")
+assets := import("@platforma-sdk/workflow-tengo:assets")
+
+math := import("math")
+
+embeddingClusteringSw := assets.importSoftware("@platforma-open/milaboratories.clonotype-clustering.software:embedding-clustering")
+processResultsSw := assets.importSoftware("@platforma-open/milaboratories.clonotype-clustering.software:process-results")
+createEmptyFilesSw := assets.importSoftware("@platforma-open/milaboratories.clonotype-clustering.software:create-empty-files")
+
+self.validateInputs({
+	"__options__,closed": "",
+	emptyOrNot: "any",
+	cloneTable: "any",
+	embeddingMatrix: "any",
+	isSingleCell: "boolean",
+	sequencesRef: "any",
+	keyCol: "string",
+	dimCol: "string",
+	valueCol: "string",
+	"minClusterSize,?": "number",
+	"mem,?": "number",
+	"cpu,?": "number"
+})
+
+// Same output keys as clustering.tpl.tengo (mmseqs/mmseqsOutput carry the saved clusters file + the
+// clustering log -- the embedding step's stdout here, surfaced by the UI as "Clustering Log").
+self.defineOutputs("abundances", "clusterToSeq", "cloneToCluster", "abundancesPerCluster", "distanceToCentroid", "clusterRadius", "clusterToSeqTop", "clusterRadiusTop", "abundancesTop", "trimmedSequences", "mmseqs", "mmseqsOutput", "isEmpty")
+
+self.body(func(inputs) {
+	mmseqs := {}
+	mmseqsOutput := {}
+
+	cloneTable := inputs.cloneTable
+	sequencesRef := inputs.sequencesRef
+	isSingleCell := inputs.isSingleCell
+	minClusterSize := is_undefined(inputs.minClusterSize) ? 5 : inputs.minClusterSize
+	// min_samples is the HDBSCAN density/noise knob -- fixed at 5 (empirically best), not user-exposed
+	minSamples := 5
+
+	baseMemGiB := 32
+	if !is_undefined(inputs.mem) {
+		baseMemGiB = inputs.mem
+	}
+
+	if string(inputs.emptyOrNot.getData()) == "empty" {
+		// Shared empty-input guard: emit empty files with proper headers (no trimming in embedding mode).
+		numSequences := len(sequencesRef)
+		emptyFilesBuilder := exec.builder().
+			software(createEmptyFilesSw).
+			mem("1GiB").
+			cpu(1).
+			arg("--num-sequences").arg(string(numSequences)).
+			arg("--trim-start").arg("0").
+			arg("--trim-end").arg("0")
+
+		if isSingleCell {
+			emptyFilesBuilder = emptyFilesBuilder.arg("--is-single-cell")
+		}
+
+		emptyFiles := emptyFilesBuilder.
+			saveFile("abundances.tsv").
+			saveFile("cluster-to-seq.tsv").
+			saveFile("clone-to-cluster.tsv").
+			saveFile("abundances-per-cluster.tsv").
+			saveFile("distance_to_centroid.tsv").
+			saveFile("cluster-radius.tsv").
+			saveFile("cluster-to-seq-top.tsv").
+			saveFile("cluster-radius-top.tsv").
+			saveFile("abundances-top.tsv").
+			saveFile("trimmed-sequences.tsv").
+			run()
+
+		return {
+			abundances: emptyFiles.getFile("abundances.tsv"),
+			clusterToSeq: emptyFiles.getFile("cluster-to-seq.tsv"),
+			cloneToCluster: emptyFiles.getFile("clone-to-cluster.tsv"),
+			abundancesPerCluster: emptyFiles.getFile("abundances-per-cluster.tsv"),
+			distanceToCentroid: emptyFiles.getFile("distance_to_centroid.tsv"),
+			clusterRadius: emptyFiles.getFile("cluster-radius.tsv"),
+			clusterToSeqTop: emptyFiles.getFile("cluster-to-seq-top.tsv"),
+			clusterRadiusTop: emptyFiles.getFile("cluster-radius-top.tsv"),
+			abundancesTop: emptyFiles.getFile("abundances-top.tsv"),
+			trimmedSequences: emptyFiles.getFile("trimmed-sequences.tsv"),
+			mmseqs: mmseqs,
+			mmseqsOutput: mmseqsOutput,
+			isEmpty: true
+		}
+	} else {
+		mem := string(baseMemGiB) + "GiB"
+		cpu := 16
+		if !is_undefined(inputs.cpu) {
+			cpu = inputs.cpu
+		}
+
+		// Step 1: embedding-distance clustering. Vector-dedup -> centered PCA-95 (cap 500, full SVD) ->
+		// L2-normalize -> HDBSCAN(eom) -> medoid representative; HDBSCAN noise -> singleton clusters.
+		// Emits the MMseqs2-format headerless clusters.tsv, a headered dedup_mapping.tsv (rep -> members),
+		// and a headered centroid_distances.tsv (per-representative cosine distance to the medoid).
+		embClust := exec.builder().
+			software(embeddingClusteringSw).
+			mem(mem).
+			cpu(cpu).
+			printErrStreamToStdout().
+			addFile("embedding.parquet", inputs.embeddingMatrix).
+			arg("--matrix").arg("embedding.parquet").
+			arg("--key-col").arg(inputs.keyCol).
+			arg("--dim-col").arg(inputs.dimCol).
+			arg("--value-col").arg(inputs.valueCol).
+			arg("--min-cluster-size").arg(string(minClusterSize)).
+			arg("--min-samples").arg(string(minSamples)).
+			saveFile("clusters.tsv").
+			saveFile("dedup_mapping.tsv").
+			saveFile("centroid_distances.tsv").
+			saveStdoutStream().
+			run()
+
+		clusters := embClust.getFile("clusters.tsv")
+		dedupMapping := embClust.getFile("dedup_mapping.tsv")
+		centroidDistances := embClust.getFile("centroid_distances.tsv")
+		mmseqsOutput := embClust.getStdoutStream()
+
+		// Step 2: aggregate (reuse process_results.py unchanged except the embedding flags). Expand
+		// reps -> members via dedup_mapping; --distances uses the precomputed cosine distances (no
+		// Levenshtein, no 1.0 cap); --no-strip-prefix because embedding keys carry no "s-" prefix.
+		result := exec.builder().
+			software(processResultsSw).
+			mem(string(int(math.max(32, baseMemGiB / 2))) + "GiB").
+			cpu(8).
+			addFile("clusters.tsv", clusters).
+			addFile("cloneTable.tsv", cloneTable).
+			addFile("dedup_mapping.tsv", dedupMapping).
+			addFile("centroid_distances.tsv", centroidDistances).
+			arg("--distances").arg("centroid_distances.tsv").
+			arg("--no-strip-prefix").
+			saveFile("abundances.tsv").
+			saveFile("cluster-to-seq.tsv").
+			saveFile("clone-to-cluster.tsv").
+			saveFile("abundances-per-cluster.tsv").
+			saveFile("distance_to_centroid.tsv").
+			saveFile("cluster-radius.tsv").
+			saveFile("cluster-to-seq-top.tsv").
+			saveFile("cluster-radius-top.tsv").
+			saveFile("abundances-top.tsv").
+			saveFile("trimmed-sequences.tsv").
+			run()
+
+		return {
+			abundances: result.getFile("abundances.tsv"),
+			clusterToSeq: result.getFile("cluster-to-seq.tsv"),
+			cloneToCluster: result.getFile("clone-to-cluster.tsv"),
+			abundancesPerCluster: result.getFile("abundances-per-cluster.tsv"),
+			distanceToCentroid: result.getFile("distance_to_centroid.tsv"),
+			clusterRadius: result.getFile("cluster-radius.tsv"),
+			clusterToSeqTop: result.getFile("cluster-to-seq-top.tsv"),
+			clusterRadiusTop: result.getFile("cluster-radius-top.tsv"),
+			abundancesTop: result.getFile("abundances-top.tsv"),
+			trimmedSequences: result.getFile("trimmed-sequences.tsv"),
+			// Save the clusters file (parity with clustering.tpl's mmseqs output) + the clustering log.
+			mmseqs: clusters,
+			mmseqsOutput: mmseqsOutput,
+			isEmpty: false
+		}
+	}
+})

--- a/workflow/src/empty-check.tpl.tengo
+++ b/workflow/src/empty-check.tpl.tengo
@@ -7,20 +7,24 @@ emptyCheckSw := assets.importSoftware("@platforma-open/milaboratories.clonotype-
 
 self.validateInputs({
 	"__options__,closed": "",
-    seqTable: "any"
+    seqTable: "any",
+    "fileName,?": "string"
 })
 
 self.defineOutputs("emptyResult")
 
 self.body(func(inputs) {
-    // Run script to check if input table is emptyAdd commentMore actions
+    // Input filename: TSV in sequence mode (default), Parquet matrix in embedding mode. emptyCheck.py
+    // reads by extension, so the same emptiness check serves both.
+    fileName := is_undefined(inputs.fileName) ? "sequences.tsv" : inputs.fileName
+    // Run script to check if input table is empty
 	emptyCheck := exec.builder().
 			software(emptyCheckSw).
 			mem("16GiB").
 			cpu(1).
-			addFile("sequences.tsv", inputs.seqTable).
+			addFile(fileName, inputs.seqTable).
 			arg("--output-dir").arg(".").
-			arg("--input").arg("sequences.tsv").
+			arg("--input").arg(fileName).
 			arg("--input-separator").arg("\t").
 			saveFileContent("isFileEmpty.txt").
 			printErrStreamToStdout().

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -90,16 +90,19 @@ wf.prepare(func(args) {
 		}, "peptideSequenceLength")
 			
 	// Resolve the selected embedding column as an explicit input (embedding mode only) — wires its
-	// producer in as an upstream and pulls the matrix. Undefined in sequence mode.
-	resolvedEmbedding := undefined
+	// producer in as an upstream and pulls the matrix.
+	//
+	// Only add the key when it has a value: the workflow framework copies every prepare-return key into
+	// a `prepared/<key>` field and PANICS assigning an undefined value (it does not skip undefined the
+	// way render() does). So in sequence mode we must NOT return `{resolvedEmbedding: undefined}`.
+	prepared := {
+		columns: bundleBuilder.build()
+	}
 	if !is_undefined(args.embeddingRef) {
-		resolvedEmbedding = wf.resolve(args.embeddingRef, { errIfMissing: true })
+		prepared.resolvedEmbedding = wf.resolve(args.embeddingRef, { errIfMissing: true })
 	}
 
-	return {
-		columns: bundleBuilder.build(),
-		resolvedEmbedding: resolvedEmbedding
-	}
+	return prepared
 })
 
 wf.body(func(args) {

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -17,6 +17,7 @@ emptyCheckTpl := assets.importTemplate(":empty-check")
 deanonimizationTpl := assets.importTemplate(":deanonimization")
 anonymizationTpl := assets.importTemplate(":anonymization")
 minPeptideLengthTpl := assets.importTemplate(":min-peptide-length")
+embeddingClusteringTpl := assets.importTemplate(":embedding-clustering")
 
 setTableProps := func(spec, label, visibility, orderPriority) {
 	visibilityValue := ""
@@ -88,8 +89,16 @@ wf.prepare(func(args) {
 			domain: { "pl7.app/feature": "peptide" }
 		}, "peptideSequenceLength")
 			
+	// Resolve the selected embedding column as an explicit input (embedding mode only) — wires its
+	// producer in as an upstream and pulls the matrix. Undefined in sequence mode.
+	resolvedEmbedding := undefined
+	if !is_undefined(args.embeddingRef) {
+		resolvedEmbedding = wf.resolve(args.embeddingRef, { errIfMissing: true })
+	}
+
 	return {
-		columns: bundleBuilder.build()
+		columns: bundleBuilder.build(),
+		resolvedEmbedding: resolvedEmbedding
 	}
 })
 
@@ -115,22 +124,49 @@ wf.body(func(args) {
 
 	// sType := args.sequenceType == "aminoacid" ? "aa" : "nt"
 
-	// input table
-	seqTableBuilder := pframes.tsvFileBuilder()
-	seqTableBuilder.mem(string(int(math.max(32, baseMemGiB / 4))) + "GiB")
-	seqTableBuilder.cpu(4)
-	
-	seqTableBuilder.setAxisHeader(datasetSpec.axesSpec[1].name, "clonotypeKey")
-	for nr, seq in sequencesRef {
-		seqTableBuilder.add(columns.getColumn(seq), {header: "sequence_" + string(nr)})
-	}
-	seqTable := seqTableBuilder.build()
+	// Clustering method + per-mode input prep. The empty-input check runs on the data the chosen method
+	// actually consumes: the sequence table in sequence mode, the embedding matrix in embedding mode.
+	clusteringMethod := is_undefined(args.clusteringMethod) ? "sequence" : args.clusteringMethod
 
-	// Check if input pcols are empty
+	seqTable := undefined
+	embeddingMatrix := undefined
+	embeddingModel := undefined
+	embSpec := undefined
+	emptyCheckInput := undefined
+	emptyCheckFileName := "sequences.tsv"
+
+	if clusteringMethod == "embedding" {
+		// embedding column resolved in prepare
+		embeddingCol := args.resolvedEmbedding
+		embSpec = embeddingCol.spec
+		// model provenance from the embedding column's spec (stamped on outputs)
+		embeddingModel = embSpec.domain["pl7.app/embedding/model"]
+		// long-format Parquet matrix; headers are the embedding column's own axis/value labels
+		embeddingMatrix = xsv.exportFrame([embeddingCol], "parquet", {
+			mem: string(int(math.max(16, baseMemGiB / 4))) + "GiB",
+			cpu: 4
+		})
+		emptyCheckInput = embeddingMatrix
+		emptyCheckFileName = "embedding.parquet"
+	} else {
+		// input (sequence) table -- sequence mode only
+		seqTableBuilder := pframes.tsvFileBuilder()
+		seqTableBuilder.mem(string(int(math.max(32, baseMemGiB / 4))) + "GiB")
+		seqTableBuilder.cpu(4)
+		seqTableBuilder.setAxisHeader(datasetSpec.axesSpec[1].name, "clonotypeKey")
+		for nr, seq in sequencesRef {
+			seqTableBuilder.add(columns.getColumn(seq), {header: "sequence_" + string(nr)})
+		}
+		seqTable = seqTableBuilder.build()
+		emptyCheckInput = seqTable
+	}
+
+	// Check if the input the chosen method consumes is empty
 	emptyCheckAnalysis := render.create(emptyCheckTpl, {
-		seqTable: seqTable
+		seqTable: emptyCheckInput,
+		fileName: emptyCheckFileName
 	})
-	
+
 	// get check content to be resolved in sub-template
 	emptyOrNot := emptyCheckAnalysis.output("emptyResult")
 
@@ -180,27 +216,52 @@ wf.body(func(args) {
 
 	/////////// Run clustering template ///////////
 	// Analysis will only run if result from emptyOrNot is "notEmpty"
-	clusteringAnalysis := render.create(clusteringTpl, {
-		emptyOrNot: emptyOrNot,
-		seqTable: seqTable,
-		cloneTable: cloneTable,
-		isSingleCell: isSingleCell,
-		isPeptide: isPeptide,
-		minPeptideLength: minPeptideLength,
-		identity: args.identity,
-		similarityType: args.similarityType,
-		coverageThreshold: args.coverageThreshold,
-		coverageMode: args.coverageMode,
-		sequencesRef: sequencesRef,
-		highPrecision: args.highPrecision,
-		trimStart: args.trimStart,
-		trimEnd: args.trimEnd,
-		clusteringTool: args.clusteringTool
-	}, {
-		metaInputs: {
-			mem: args.mem,
-			cpu: args.cpu
-	}})
+	// Dispatch on clustering method.
+	// - Sequence mode -> clustering.tpl (MMseqs2, untouched)
+	// - Embedding mode -> embedding-clustering.tpl, reusing the embedding 
+	//   matrix / spec / model already computed above. 
+	// Both honor the same output-file contract.
+	clusteringAnalysis := undefined
+	if clusteringMethod == "embedding" {
+		clusteringAnalysis = render.create(embeddingClusteringTpl, {
+			emptyOrNot: emptyOrNot,
+			cloneTable: cloneTable,
+			embeddingMatrix: embeddingMatrix,
+			isSingleCell: isSingleCell,
+			sequencesRef: sequencesRef,
+			// matrix headers are the embedding column's own axis/value pl7.app/label values
+			keyCol: embSpec.axesSpec[0].annotations["pl7.app/label"],
+			dimCol: embSpec.axesSpec[1].annotations["pl7.app/label"],
+			valueCol: embSpec.annotations["pl7.app/label"],
+			minClusterSize: args.minClusterSize
+		}, {
+			metaInputs: {
+				mem: args.mem,
+				cpu: args.cpu
+		}})
+	} else {
+		clusteringAnalysis = render.create(clusteringTpl, {
+			emptyOrNot: emptyOrNot,
+			seqTable: seqTable,
+			cloneTable: cloneTable,
+			isSingleCell: isSingleCell,
+			isPeptide: isPeptide,
+			minPeptideLength: minPeptideLength,
+			identity: args.identity,
+			similarityType: args.similarityType,
+			coverageThreshold: args.coverageThreshold,
+			coverageMode: args.coverageMode,
+			sequencesRef: sequencesRef,
+			highPrecision: args.highPrecision,
+			trimStart: args.trimStart,
+			trimEnd: args.trimEnd,
+			clusteringTool: args.clusteringTool
+		}, {
+			metaInputs: {
+				mem: args.mem,
+				cpu: args.cpu
+		}})
+	}
 
 	// Gather raw results from clusteringAnalysis template
 	mmseqs := clusteringAnalysis.output("mmseqs")
@@ -211,14 +272,21 @@ wf.body(func(args) {
 	trimStart := is_undefined(args.trimStart) ? 0 : args.trimStart
 	trimEnd := is_undefined(args.trimEnd) ? 0 : args.trimEnd
 
+	// Cluster output domain: algorithm + blockId, plus the embedding model in embedding mode, so
+	// embedding-derived clusters are distinguishable and traceable. Shared by clusterId and
+	// distanceToCentroid below.
+	clusterDomain := {
+		"pl7.app/clustering/algorithm": clusteringMethod == "embedding" ? "embedding-hdbscan" : "mmseqs2",
+		"pl7.app/clustering/blockId": blockId
+	}
+	if clusteringMethod == "embedding" && !is_undefined(embeddingModel) {
+		clusterDomain["pl7.app/embedding/model"] = embeddingModel
+	}
+
 	clusterIdAxisSpec := {
 		name: "pl7.app/clusterId",
 		type: "String",
-		domain: maps.deepMerge(datasetSpec.axesSpec[1].domain,
-		{
-			"pl7.app/clustering/algorithm": "mmseqs2",
-			"pl7.app/clustering/blockId": blockId
-		}),
+		domain: maps.deepMerge(datasetSpec.axesSpec[1].domain, clusterDomain),
 		annotations: {
 			"pl7.app/label": "Cluster Id",
 			"pl7.app/table/visibility": "default",
@@ -494,10 +562,7 @@ wf.body(func(args) {
 			spec: setTableProps({
 				name: "pl7.app/distanceToCentroid",
 				valueType: "Float",
-				domain:  {
-					"pl7.app/clustering/algorithm": "mmseqs2",
-					"pl7.app/clustering/blockId": blockId
-				},
+				domain: clusterDomain,
 				annotations: {
 					"pl7.app/min": "0",
 					"pl7.app/max": "1",


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a new **embedding-distance clustering mode** (HDBSCAN on ESM-2 / other embedding vectors) as an alternative to the existing MMseqs2 sequence-identity path. The feature is opt-in and backwards-compatible — existing projects load in sequence mode via a migration upgrade.

- **New Python script** (`embedding_clustering.py`): vector deduplication → centered PCA (95% variance) → L2-normalisation → HDBSCAN (eom) → medoid selection; outputs the same `clusters.tsv` / `dedup_mapping.tsv` / `centroid_distances.tsv` file contract consumed by `process_results.py`, which is extended with `--distances` and `--no-strip-prefix` flags for embedding mode.
- **New Tengo template** (`embedding-clustering.tpl.tengo`): dispatched from `main.tpl.tengo` when `clusteringMethod === "embedding"`; honours the same output-file contract as the MMseqs2 path so the pFrame assembly logic is shared.
- **UI additions** (`MainPage.vue`, `app.ts`): method toggle (hidden until an embedding column is discoverable), embedding-ref dropdown, auto-derivation of source sequence columns for the centroid/MSA view, and a guard that falls back to sequence mode if the upstream embedding block is removed.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The clustering logic and file-contract plumbing are solid, but the distanceToCentroid and clusterRadius output specs carry a hardcoded max: 1 that is inconsistent with the 0-2 range of cosine distance actually produced in embedding mode.

The pl7.app/max: 1 annotation on three pFrame column specs (distanceToCentroid, clusterRadius, clusterRadiusTop) does not match the documented 0-2 range of cosine distances emitted by embedding_clustering.py; process_results.py even calls this out with 'NO 1.0 cap'. Any UI widget or downstream tool that uses the annotation as a display ceiling will silently misrepresent values above 1.0 for every embedding-mode user, which is the primary new feature of this PR.

workflow/src/main.tpl.tengo (distanceToCentroid and clusterRadius max annotations), software/src/embedding_clustering.py (dim_col sort assumption in load_matrix)
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| workflow/src/main.tpl.tengo | Adds embedding-mode dispatch to the main workflow. The pl7.app/max: 1 annotation on distanceToCentroid and clusterRadius is wrong for embedding mode (cosine distance ranges 0-2), causing incorrect visualisation scaling. |
| software/src/embedding_clustering.py | New Python script for HDBSCAN-based embedding clustering. Core algorithms (medoid selection, PCA, dedup) are sound; minor concerns around exact-float dedup assumption and string-type dim_col sort ordering. |
| model/src/index.ts | Adds embedding clustering fields to BlockData, extends getDefaultBlockLabel for embedding mode, adds embeddingOptions output, and updates args projection with correct V3 conditional suppression. |
| software/src/process_results.py | Extended to support embedding mode via --distances and --no-strip-prefix flags. Correctly bypasses Levenshtein computation and imports precomputed cosine distances with no 1.0 cap. |
| workflow/src/embedding-clustering.tpl.tengo | New Tengo template for embedding-clustering path. Matches the output-file contract of clustering.tpl correctly; correctly passes --no-strip-prefix and --distances to process_results. |
| ui/src/app.ts | Adds embedding-mode branch to syncDefaultBlockLabel; reactive effect correctly handles method switching and label derivation. |
| ui/src/pages/MainPage.vue | Adds embedding method selector, embedding-ref dropdown, auto-derivation of source sequence columns, and fallback guard when embeddings become unavailable. |
| software/src/emptyCheck.py | Extended to detect Parquet inputs by extension and use Polars for the empty check; TSV path unchanged. |
| workflow/src/empty-check.tpl.tengo | Adds optional fileName parameter so the same empty-check template serves both TSV (sequence mode) and Parquet (embedding mode) inputs. |
| software/src/requirements.txt | Adds scikit-learn==1.6.1 and numpy==2.2.6 for HDBSCAN and PCA in embedding_clustering.py; polars-lts-cpu already present covers the polars import. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User selects dataset] --> B{clusteringMethod}
    B -->|sequence| C[MMseqs2 path\nclustering.tpl.tengo]
    B -->|embedding| D[Embedding path\nembedding-clustering.tpl.tengo]
    D --> E[emptyCheck.py\nParquet matrix]
    E -->|notEmpty| F[embedding_clustering.py\nvector dedup → PCA-95 → L2-norm → HDBSCAN → medoids\nclusters.tsv + dedup_mapping.tsv + centroid_distances.tsv]
    E -->|empty| G[create-empty-files\n→ all output TSVs]
    C --> H[process_results.py\nstandard flags]
    F --> I[process_results.py\n--distances --no-strip-prefix]
    H --> J[main.tpl.tengo\npFrame assembly]
    I --> J
    J --> K[distanceToCentroid pFrame\nmax annotation: 1 ⚠️ should be 2 in embedding mode]
    J --> L[clusterRadius pFrame\nmax annotation: 1 ⚠️ should be 2 in embedding mode]
    J --> M[abundances / clusterToSeq / cloneToCluster pFrames]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User selects dataset] --> B{clusteringMethod}
    B -->|sequence| C[MMseqs2 path\nclustering.tpl.tengo]
    B -->|embedding| D[Embedding path\nembedding-clustering.tpl.tengo]
    D --> E[emptyCheck.py\nParquet matrix]
    E -->|notEmpty| F[embedding_clustering.py\nvector dedup → PCA-95 → L2-norm → HDBSCAN → medoids\nclusters.tsv + dedup_mapping.tsv + centroid_distances.tsv]
    E -->|empty| G[create-empty-files\n→ all output TSVs]
    C --> H[process_results.py\nstandard flags]
    F --> I[process_results.py\n--distances --no-strip-prefix]
    H --> J[main.tpl.tengo\npFrame assembly]
    I --> J
    J --> K[distanceToCentroid pFrame\nmax annotation: 1 ⚠️ should be 2 in embedding mode]
    J --> L[clusterRadius pFrame\nmax annotation: 1 ⚠️ should be 2 in embedding mode]
    J --> M[abundances / clusterToSeq / cloneToCluster pFrames]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `workflow/src/main.tpl.tengo`, line 563-572 ([link](https://github.com/platforma-open/clonotype-clustering/blob/041273d7853bdaf6c84559c8f2c796cadd49dc7f/workflow/src/main.tpl.tengo#L563-L572)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`pl7.app/max: "1"` is wrong for embedding-mode cosine distances**

   `distanceToCentroid` in embedding mode is computed as `1 - dot(Xn_member, Xn_medoid)` on L2-normalised vectors, so cosine similarity lies in `[-1, 1]` and cosine distance lies in `[0, 2]`. `process_results.py` explicitly documents "NO 1.0 cap -- cosine distance ranges 0-2". Annotating `"pl7.app/max": "1"` causes any visualisation that uses this annotation as an axis ceiling (colour ramp, normalization bar, etc.) to silently truncate or distort values above 1.0 for every embedding-mode run.

   The same mismatch affects the `clusterRadiusPf` at line 590 and `clusterRadiusTopPf` at line 690, both of which are derived from the same cosine-distance column. The annotation should be `"2"` (or made conditional on `clusteringMethod`).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: workflow/src/main.tpl.tengo
   Line: 563-572

   Comment:
   **`pl7.app/max: "1"` is wrong for embedding-mode cosine distances**

   `distanceToCentroid` in embedding mode is computed as `1 - dot(Xn_member, Xn_medoid)` on L2-normalised vectors, so cosine similarity lies in `[-1, 1]` and cosine distance lies in `[0, 2]`. `process_results.py` explicitly documents "NO 1.0 cap -- cosine distance ranges 0-2". Annotating `"pl7.app/max": "1"` causes any visualisation that uses this annotation as an axis ceiling (colour ramp, normalization bar, etc.) to silently truncate or distort values above 1.0 for every embedding-mode run.

   The same mismatch affects the `clusterRadiusPf` at line 590 and `clusterRadiusTopPf` at line 690, both of which are derived from the same cosine-distance column. The annotation should be `"2"` (or made conditional on `clusteringMethod`).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
workflow/src/main.tpl.tengo:563-572
**`pl7.app/max: "1"` is wrong for embedding-mode cosine distances**

`distanceToCentroid` in embedding mode is computed as `1 - dot(Xn_member, Xn_medoid)` on L2-normalised vectors, so cosine similarity lies in `[-1, 1]` and cosine distance lies in `[0, 2]`. `process_results.py` explicitly documents "NO 1.0 cap -- cosine distance ranges 0-2". Annotating `"pl7.app/max": "1"` causes any visualisation that uses this annotation as an axis ceiling (colour ramp, normalization bar, etc.) to silently truncate or distort values above 1.0 for every embedding-mode run.

The same mismatch affects the `clusterRadiusPf` at line 590 and `clusterRadiusTopPf` at line 690, both of which are derived from the same cosine-distance column. The annotation should be `"2"` (or made conditional on `clusteringMethod`).

### Issue 2 of 3
software/src/embedding_clustering.py:99-106
**`vector_dedup` silently de-duplicates on exact bit-equality only**

`np.unique(Xs, axis=0)` compares rows by exact floating-point equality. Because the function sorts `X` by clonotype key first (`order = np.argsort(keys, kind="stable")`), the "first occurrence = minimum key" representative selection is correct. However, the comment "bit-identical for same-model/same-sequence embeddings" is a strong assumption: if the upstream embedding pipeline ever applies any per-row transform (e.g. casting, re-normalizing) that breaks exact equality for genuinely identical sequences, no deduplication will occur and the M will equal N, which inflates the HDBSCAN cost without producing wrong results but harms performance.

Consider adding a brief note or a configurable tolerance path for near-duplicate detection in the docstring.

### Issue 3 of 3
software/src/embedding_clustering.py:169-186
**`load_matrix` may produce a scrambled matrix if dim values are stored as strings**

The function relies on `sort([key_col, dim_col])` to group each clonotype's D embedding values contiguously, then `reshape(n, D)`. If the Parquet file stores `dim_col` as a string type (e.g. `"0"`, `"1"`, ..., `"9"`, `"10"`, …), the sort is lexicographic and dimension order becomes `"0", "1", "10", "2", ...`. The `df.height % n != 0` guard only catches unequal-D inputs; it does not catch a valid-D but mis-ordered reshape that silently permutes the feature vector. The reshape still succeeds, but each row in `X` has scrambled dimensions from position 10 onward for any model with more than 9 dimensions (virtually all real-world embeddings). A pre-sort cast or an explicit check that `dim_col` has an integer dtype would harden this path.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["First version"](https://github.com/platforma-open/clonotype-clustering/commit/041273d7853bdaf6c84559c8f2c796cadd49dc7f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37864316)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->