### PR TITLE
Automatically select clustering tool

### DIFF
--- a/.changeset/auto-switch-clustering-algorithm-by-size.md
+++ b/.changeset/auto-switch-clustering-algorithm-by-size.md
@@ -1,0 +1,6 @@
+---
+'@platforma-open/milaboratories.clonotype-clustering.model': patch
+'@platforma-open/milaboratories.clonotype-clustering.ui': patch
+---
+
+Auto-select the clustering algorithm by dataset size: when the selected dataset exceeds the row threshold, switch to linear-time easy-linclust; otherwise use easy-cluster. The model exposes the selected dataset's row count (via getNumberOfRows) as the `datasetSize` output, and the UI applies the algorithm switch reactively.

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -39,7 +39,7 @@ export const clusteringToolOptions = [
  * prohibitively slow; linclust (linear-time) is auto-selected instead. Applied
  * on dataset selection in the UI — see `datasetSize` and `setInput`.
  */
-export const LARGE_DATASET_ROW_THRESHOLD = 1_000;
+export const LARGE_DATASET_ROW_THRESHOLD = 1_000_000;
 
 /** Selectors for the anchor (abundance) columns offered as the input dataset. */
 const datasetMatchers = [

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -15,6 +15,7 @@ import {
   createPFrameForGraphs,
   createPlDataTableStateV2,
   createPlDataTableV2,
+  getNumberOfRows,
 } from "@platforma-sdk/model";
 export type * from "@milaboratories/helpers";
 
@@ -32,6 +33,29 @@ export const clusteringToolOptions = [
   { label: "Easy Cluster", value: "easy-cluster" },
   { label: "Easy Linclust", value: "easy-linclust" },
 ] as const;
+
+/**
+ * Above this many input rows, the cascaded easy-cluster algorithm becomes
+ * prohibitively slow; linclust (linear-time) is auto-selected instead. Applied
+ * on dataset selection in the UI — see `datasetSizeByRef` and `setInput`.
+ */
+export const LARGE_DATASET_ROW_THRESHOLD = 1_000_000;
+
+/** Selectors for the anchor (abundance) columns offered as the input dataset. */
+const datasetMatchers = [
+  {
+    axes: [{ name: "pl7.app/sampleId" }, { name: "pl7.app/vdj/clonotypeKey" }],
+    annotations: { "pl7.app/isAnchor": "true" },
+  },
+  {
+    axes: [{ name: "pl7.app/sampleId" }, { name: "pl7.app/vdj/scClonotypeKey" }],
+    annotations: { "pl7.app/isAnchor": "true" },
+  },
+  {
+    axes: [{ name: "pl7.app/sampleId" }, { name: "pl7.app/variantKey" }],
+    annotations: { "pl7.app/isAnchor": "true" },
+  },
+];
 
 type OldArgs = {
   defaultBlockLabel: string;
@@ -204,27 +228,23 @@ export const platforma = BlockModelV3.create(dataModel)
   })
 
   .output("datasetOptions", (ctx) =>
-    ctx.resultPool.getOptions(
-      [
-        {
-          axes: [{ name: "pl7.app/sampleId" }, { name: "pl7.app/vdj/clonotypeKey" }],
-          annotations: { "pl7.app/isAnchor": "true" },
-        },
-        {
-          axes: [{ name: "pl7.app/sampleId" }, { name: "pl7.app/vdj/scClonotypeKey" }],
-          annotations: { "pl7.app/isAnchor": "true" },
-        },
-        {
-          axes: [{ name: "pl7.app/sampleId" }, { name: "pl7.app/variantKey" }],
-          annotations: { "pl7.app/isAnchor": "true" },
-        },
-      ],
-      {
-        // suppress native label of the column (e.g. "Number of Reads") to show only the dataset label
-        label: { includeNativeLabel: false },
-      },
-    ),
+    ctx.resultPool.getOptions(datasetMatchers, {
+      // suppress native label of the column (e.g. "Number of Reads") to show only the dataset label
+      label: { includeNativeLabel: false },
+    }),
   )
+
+  // Row count of the currently selected dataset, used by the UI to auto-pick the
+  // clustering algorithm. getNumberOfRows reads parquet chunk stats from resource
+  // metadata without downloading blobs, and returns undefined for non-parquet /
+  // not-yet-ready data — in which case the UI leaves the algorithm untouched.
+  .output("datasetSize", (ctx): number | undefined => {
+    const ref = ctx.data.datasetRef;
+    if (ref === undefined) return undefined;
+    const col = ctx.resultPool.getPColumnByRef(ref);
+    if (col === undefined) return undefined;
+    return getNumberOfRows(col.data);
+  })
 
   .output("sequenceOptions", (ctx) => {
     const ref = ctx.data.datasetRef;

--- a/model/src/index.ts
+++ b/model/src/index.ts
@@ -37,9 +37,9 @@ export const clusteringToolOptions = [
 /**
  * Above this many input rows, the cascaded easy-cluster algorithm becomes
  * prohibitively slow; linclust (linear-time) is auto-selected instead. Applied
- * on dataset selection in the UI — see `datasetSizeByRef` and `setInput`.
+ * on dataset selection in the UI — see `datasetSize` and `setInput`.
  */
-export const LARGE_DATASET_ROW_THRESHOLD = 1_000_000;
+export const LARGE_DATASET_ROW_THRESHOLD = 1_000;
 
 /** Selectors for the anchor (abundance) columns offered as the input dataset. */
 const datasetMatchers = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: 2.11.0
       version: 2.11.0
     '@platforma-sdk/model':
-      specifier: 1.79.6
-      version: 1.79.6
+      specifier: 1.79.14
+      version: 1.79.14
     '@platforma-sdk/package-builder':
       specifier: 3.13.0
       version: 3.13.0
@@ -46,14 +46,14 @@ catalogs:
       specifier: 4.0.8
       version: 4.0.8
     '@platforma-sdk/test':
-      specifier: 1.79.12
-      version: 1.79.12
+      specifier: 1.79.14
+      version: 1.79.14
     '@platforma-sdk/ui-vue':
-      specifier: 1.79.11
-      version: 1.79.11
+      specifier: 1.79.14
+      version: 1.79.14
     '@platforma-sdk/workflow-tengo':
-      specifier: 6.6.2
-      version: 6.6.2
+      specifier: 6.6.3
+      version: 6.6.3
     eslint:
       specifier: ^9.25.1
       version: 9.39.2
@@ -126,7 +126,7 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.5(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.4.5(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)(@platforma-sdk/ui-vue@1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@milaboratories/helpers':
         specifier: 'catalog:'
         version: 1.14.2
@@ -135,7 +135,7 @@ importers:
         version: 0.1.2
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.6
+        version: 1.79.14
       '@types/node':
         specifier: '*'
         version: 24.5.2
@@ -182,7 +182,7 @@ importers:
         version: 1.2.3
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.12(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.3.5(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1))
+        version: 1.79.14(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.3.5(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1))
       eslint:
         specifier: 'catalog:'
         version: 9.39.2
@@ -194,10 +194,10 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.5(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.4.5(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)(@platforma-sdk/ui-vue@1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@milaboratories/multi-sequence-alignment':
         specifier: 'catalog:'
-        version: 1.47.15(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.47.15(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)(@platforma-sdk/ui-vue@1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -206,10 +206,10 @@ importers:
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.6
+        version: 1.79.14
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+        version: 1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@types/node':
         specifier: '*'
         version: 24.5.2
@@ -240,14 +240,14 @@ importers:
         version: 1.18.0
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 6.6.2
+        version: 6.6.3
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
         version: 4.0.8
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.12(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
+        version: 1.79.14(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -1207,8 +1207,8 @@ packages:
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.64.30':
-    resolution: {integrity: sha512-ZuppY/3H++vYTu+7OGJ4mexNfhEml6g6pb9qsOUow9WHgde1sa1YqWLCKSIVFAO8AeBDLpgFFxAG83EeeKA9tA==}
+  '@milaboratories/pl-middle-layer@1.64.32':
+    resolution: {integrity: sha512-tBBTm3EsVfJQDTsaUbG/gD889etZGS2qmOS//51l+YCtWzEmPmnNDvMHlI5rmIYOtuQJH91ZmvFEPj3nGCweqw==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-model-backend@1.4.7':
@@ -1258,8 +1258,8 @@ packages:
     resolution: {integrity: sha512-HK3AmNZl2fOzMHot2+ihKsOC+fluwhl5261VTn1zGS3LRpmC9bCk/po8SzsVmg79ccI5nESFTdz+BRaLsXncmQ==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.15.7':
-    resolution: {integrity: sha512-R1bHkxgYokVB7QKkVTAC3Zmdv2acskOGqd/vw/tpg0xsGKO2aUQ4k+gEp0dEsC4yf4nA0zU9Dd6oNGJ1NA3NeQ==}
+  '@milaboratories/uikit@2.15.8':
+    resolution: {integrity: sha512-kyG9VJI7zeX6XQIu+93qFJFTvoOeoW7AqNdtkrTmSHet4FNCdYfp05DKA2lku6WuiYg/bHfpEhRLbu7US8Fs9g==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -1584,8 +1584,8 @@ packages:
   '@platforma-open/milaboratories.software-ptabler.schema@1.15.14':
     resolution: {integrity: sha512-BBbmfUi3fS40HmMbYKGuRNgSPo4kAk/vk+dUK3fyabbjGncKZTm9W4vZlqH2JJX0VECIROR4FrvGvF91yRyVwg==}
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.1':
-    resolution: {integrity: sha512-s1Mqs/zHYXHFqQpXCDsqEKDrZr8auhNz32JciU2CTTFxbVzm6QCHpZNh7gLpyc74YK3Nrfcy1fjl/8GMreNMNA==}
+  '@platforma-open/milaboratories.software-ptabler@2.1.2':
+    resolution: {integrity: sha512-pCPA9oa4MPZ8mw7tJRjp4Zy9e/xJL9+tWKlSVXd+PbSkAqZoPTirf1izWV/NEZhhM7w8przq4jGhbqj6ukkCRQ==}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2':
     resolution: {integrity: sha512-I08YpKQ4+esLrfpVra5UJ+bznI9Zzba6OW0rKK407a1EUmanvYMVrCbM9gqnm6CHbv2vQxNGSaO8p1LoBh+9gA==}
@@ -1619,8 +1619,8 @@ packages:
     resolution: {integrity: sha512-p9lBxhFXM9WoRsrJO7dfkiXSK+1m63yIn1sKhBO71eMbhrLMyVYHEOeNf3w5OCdbRF5QsNhXzWuiTmFK3zHFsA==}
     hasBin: true
 
-  '@platforma-sdk/model@1.79.6':
-    resolution: {integrity: sha512-aLgxJQQj07+uNYXiQHvFwFG34tgDC+NxvihMJ89dYKdgLPGDMlamIN4bxXco4W3uFqujQNTOqMed7cMeF3UYxA==}
+  '@platforma-sdk/model@1.79.14':
+    resolution: {integrity: sha512-ywF+pV3twqbZfuGv+fphE7HKZzYY9/xYIM9gvhM3Ps/qusIf98997C8Ickky1uHd6AHk8YUX78HCR4hJkD7FyQ==}
 
   '@platforma-sdk/package-builder@3.13.0':
     resolution: {integrity: sha512-5dMFx1S8cotsWd9rccJlyRH00j43f9JFzLmuMGqwKCdfv+T0TADBWvbFRv1oD+kr5gRGj++Ud5GUIVVUUr6suw==}
@@ -1631,14 +1631,14 @@ packages:
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.79.12':
-    resolution: {integrity: sha512-ViHnAgFFFyc80erocCGo90msJxcAJzJgeEbo1X3eBS4/75WcHG24bipw6ylSzfnBrT4KzWXa+0gxqfef+00a+Q==}
+  '@platforma-sdk/test@1.79.14':
+    resolution: {integrity: sha512-YswflyuQRmZ6pgkR0+gL6YN38bt/MFuugnBG6NJpjkda/SSoXaiIb3HcBNw0Y+mpyAQPHMoSyHr7ZyZGpvZVDA==}
 
-  '@platforma-sdk/ui-vue@1.79.11':
-    resolution: {integrity: sha512-i5rC0xfdKNRTDRNO53l9/Xte0gIJDBrKk59f3pHXrUBhxef5CnNd9tqdWAu7Dw+6SZT2cQmS3+QvfvdqzbkHFw==}
+  '@platforma-sdk/ui-vue@1.79.14':
+    resolution: {integrity: sha512-KRc+4YOKKes1uwpKBgx9PeJozpGOS2uLt4XljgFupnoU4PyNZjw2I8ZTLtvq0Ld9o5T/ieUCRgiXgx4i4O+QBg==}
 
-  '@platforma-sdk/workflow-tengo@6.6.2':
-    resolution: {integrity: sha512-KlkvO3BrlQOP9/fdtsAfV1gDUjnePGiAntGN19Bz1LOOxF1Ukw02W726jtTOgpG7jPKGhDmeCLkARAn9IfSgxw==}
+  '@platforma-sdk/workflow-tengo@6.6.3':
+    resolution: {integrity: sha512-2H83hEd+t8pIcSpz0anmWb0wesEcoXCYl9HSOcfQL9b0ro6EDf+PwyafXtmbXl2kMtkpccigbhDGZdDhoMpr7w==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -7631,14 +7631,14 @@ snapshots:
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
-  '@milaboratories/graph-maker@1.4.5(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
+  '@milaboratories/graph-maker@1.4.5(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)(@platforma-sdk/ui-vue@1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.5
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.3(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)
-      '@platforma-sdk/model': 1.79.6
-      '@platforma-sdk/ui-vue': 1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+      '@milaboratories/pf-plots': 1.4.3(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)
+      '@platforma-sdk/model': 1.79.14
+      '@platforma-sdk/ui-vue': 1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@types/d3-hierarchy': 3.1.7
       '@types/d3-scale': 4.0.9
       '@vueuse/core': 13.4.0(vue@3.5.25(typescript@5.9.3))
@@ -7695,13 +7695,13 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/multi-sequence-alignment@1.47.15(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)(@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
+  '@milaboratories/multi-sequence-alignment@1.47.15(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)(@platforma-sdk/ui-vue@1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
     dependencies:
       '@milaboratories/biowasm-tools': 2.0.3
       '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.3(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)
-      '@platforma-sdk/model': 1.79.6
-      '@platforma-sdk/ui-vue': 1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+      '@milaboratories/pf-plots': 1.4.3(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)
+      '@platforma-sdk/model': 1.79.14
+      '@platforma-sdk/ui-vue': 1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       vue: 3.5.25(typescript@5.9.3)
     transitivePeerDependencies:
       - '@milaboratories/pl-model-common'
@@ -7726,11 +7726,11 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-plots@1.4.3(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.6)':
+  '@milaboratories/pf-plots@1.4.3(@milaboratories/pl-model-common@1.46.1)(@platforma-sdk/model@1.79.14)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-model-common': 1.46.1
-      '@platforma-sdk/model': 1.79.6
+      '@platforma-sdk/model': 1.79.14
       canonicalize: 2.1.0
       lodash: 4.17.21
 
@@ -7858,7 +7858,7 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.64.30(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
+  '@milaboratories/pl-middle-layer@1.64.32(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
     dependencies:
       '@milaboratories/computable': 2.9.5
       '@milaboratories/helpers': 1.14.2
@@ -7878,8 +7878,8 @@ snapshots:
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/ts-helpers': 1.8.3
       '@platforma-sdk/block-tools': 2.11.0(@types/node@24.5.2)
-      '@platforma-sdk/model': 1.79.6
-      '@platforma-sdk/workflow-tengo': 6.6.2
+      '@platforma-sdk/model': 1.79.14
+      '@platforma-sdk/workflow-tengo': 6.6.3
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.39.10
@@ -8084,10 +8084,10 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.15.7(typescript@5.9.3)':
+  '@milaboratories/uikit@2.15.8(typescript@5.9.3)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@platforma-sdk/model': 1.79.6
+      '@platforma-sdk/model': 1.79.14
       '@types/d3-array': 3.2.1
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -8395,7 +8395,7 @@ snapshots:
     dependencies:
       '@milaboratories/pl-model-common': 1.46.1
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.1': {}
+  '@platforma-open/milaboratories.software-ptabler@2.1.2': {}
 
   '@platforma-open/milaboratories.software-ptexter@1.2.2': {}
 
@@ -8447,7 +8447,7 @@ snapshots:
     dependencies:
       yaml: 2.8.1
 
-  '@platforma-sdk/model@1.79.6':
+  '@platforma-sdk/model@1.79.14':
     dependencies:
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/pl-error-like': 1.12.10
@@ -8485,13 +8485,13 @@ snapshots:
       '@oclif/core': 4.2.6
       winston: 3.17.0
 
-  '@platforma-sdk/test@1.79.12(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.3.5(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1))':
+  '@platforma-sdk/test@1.79.14(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.3.5(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1))':
     dependencies:
       '@milaboratories/computable': 2.9.5
       '@milaboratories/pl-client': 3.11.4
-      '@milaboratories/pl-middle-layer': 1.64.30(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
+      '@milaboratories/pl-middle-layer': 1.64.32(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
       '@milaboratories/pl-tree': 1.12.12
-      '@platforma-sdk/model': 1.79.6
+      '@platforma-sdk/model': 1.79.14
       '@vitest/coverage-istanbul': 4.1.5(vitest@4.0.8(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1))
       vitest: 4.1.5(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.5)(vite@6.3.5(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1))
     transitivePeerDependencies:
@@ -8512,13 +8512,13 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/test@1.79.12(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))':
+  '@platforma-sdk/test@1.79.14(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))':
     dependencies:
       '@milaboratories/computable': 2.9.5
       '@milaboratories/pl-client': 3.11.4
-      '@milaboratories/pl-middle-layer': 1.64.30(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
+      '@milaboratories/pl-middle-layer': 1.64.32(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
       '@milaboratories/pl-tree': 1.12.12
-      '@platforma-sdk/model': 1.79.6
+      '@platforma-sdk/model': 1.79.14
       '@vitest/coverage-istanbul': 4.1.5(vitest@4.1.5)
       vitest: 4.1.5(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.5)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
     transitivePeerDependencies:
@@ -8539,12 +8539,12 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.79.11(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
+  '@platforma-sdk/ui-vue@1.79.14(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
     dependencies:
       '@milaboratories/pf-spec-driver': 1.4.13(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pl-model-common': 1.46.1
-      '@milaboratories/uikit': 2.15.7(typescript@5.9.3)
-      '@platforma-sdk/model': 1.79.6
+      '@milaboratories/uikit': 2.15.8(typescript@5.9.3)
+      '@platforma-sdk/model': 1.79.14
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.0
@@ -8575,11 +8575,11 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@6.6.2':
+  '@platforma-sdk/workflow-tengo@6.6.3':
     dependencies:
       '@milaboratories/pframes-rs-wasip2': 1.1.50
       '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 2.1.1
+      '@platforma-open/milaboratories.software-ptabler': 2.1.2
       '@platforma-open/milaboratories.software-ptexter': 1.2.2
       '@platforma-open/milaboratories.software-small-binaries': 2.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,13 +10,13 @@ catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
   '@milaboratories/ts-builder': 1.5.2
   '@milaboratories/ts-configs': 1.2.3
-  '@platforma-sdk/workflow-tengo': 6.6.2
-  '@platforma-sdk/model': 1.79.6
-  '@platforma-sdk/ui-vue': 1.79.11
+  '@platforma-sdk/workflow-tengo': 6.6.3
+  '@platforma-sdk/model': 1.79.14
+  '@platforma-sdk/ui-vue': 1.79.14
   '@platforma-sdk/tengo-builder': 4.0.8
   '@platforma-sdk/package-builder': 3.13.0
   '@platforma-sdk/block-tools': 2.11.0
-  '@platforma-sdk/test': 1.79.12
+  '@platforma-sdk/test': 1.79.14
   '@milaboratories/helpers': 1.14.2
   '@milaboratories/strings': 0.1.2
 

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -3,6 +3,7 @@ import { PlMultiSequenceAlignment } from "@milaboratories/multi-sequence-alignme
 import strings from "@milaboratories/strings";
 import {
   clusteringToolOptions,
+  LARGE_DATASET_ROW_THRESHOLD,
   similarityTypeOptions,
 } from "@platforma-open/milaboratories.clonotype-clustering.model";
 import type {
@@ -76,6 +77,26 @@ const onRowDoubleClicked = reactive((key?: PTableKey) => {
 function setInput(inputRef?: PlRef) {
   app.model.data.datasetRef = inputRef;
 }
+
+// Auto-select the clustering algorithm by dataset size: cascaded easy-cluster is
+// too slow on very large inputs, so switch to linear-time linclust above the
+// threshold. The model resolves the selected dataset's row count one tick after
+// datasetRef changes, so we react to that value rather than computing in setInput.
+//
+// This writes data from a watcher on an output, but it is NOT a hairpin:
+// clusteringTool does not feed back into datasetSize (no loop), and the written
+// value is fully determined by the dataset, so concurrent clients converge on the
+// same result instead of racing. It fires only when the size actually changes, so
+// a later manual choice in Advanced Settings is preserved. Size unknown
+// (non-parquet / not yet ready) -> leave the current choice untouched.
+watch(
+  () => app.model.outputs.datasetSize,
+  (size) => {
+    if (size === undefined) return;
+    app.model.data.clusteringTool =
+      size > LARGE_DATASET_ROW_THRESHOLD ? "easy-linclust" : "easy-cluster";
+  },
+);
 
 const tableSettings = usePlDataTableSettingsV2({
   model: () => app.model.outputs.clustersTable,

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -74,8 +74,14 @@ const onRowDoubleClicked = reactive((key?: PTableKey) => {
   multipleSequenceAlignmentOpen.value = true;
 });
 
+// Set when the user interactively picks a dataset; consumed once that dataset's
+// size resolves (the model reports it a tick later). Kept in local Vue state, not
+// in `data` — it is transient UI intent, never persisted.
+const pendingSizeAutoSelect = ref(false);
+
 function setInput(inputRef?: PlRef) {
   app.model.data.datasetRef = inputRef;
+  pendingSizeAutoSelect.value = inputRef !== undefined;
 }
 
 // Auto-select the clustering algorithm by dataset size: cascaded easy-cluster is
@@ -84,7 +90,8 @@ function setInput(inputRef?: PlRef) {
 watch(
   () => app.model.outputs.datasetSize,
   (size) => {
-    if (size === undefined) return;
+    if (!pendingSizeAutoSelect.value || size === undefined) return;
+    pendingSizeAutoSelect.value = false;
     app.model.data.clusteringTool =
       size > LARGE_DATASET_ROW_THRESHOLD ? "easy-linclust" : "easy-cluster";
   },

--- a/ui/src/pages/MainPage.vue
+++ b/ui/src/pages/MainPage.vue
@@ -80,15 +80,7 @@ function setInput(inputRef?: PlRef) {
 
 // Auto-select the clustering algorithm by dataset size: cascaded easy-cluster is
 // too slow on very large inputs, so switch to linear-time linclust above the
-// threshold. The model resolves the selected dataset's row count one tick after
-// datasetRef changes, so we react to that value rather than computing in setInput.
-//
-// This writes data from a watcher on an output, but it is NOT a hairpin:
-// clusteringTool does not feed back into datasetSize (no loop), and the written
-// value is fully determined by the dataset, so concurrent clients converge on the
-// same result instead of racing. It fires only when the size actually changes, so
-// a later manual choice in Advanced Settings is preserved. Size unknown
-// (non-parquet / not yet ready) -> leave the current choice untouched.
+// threshold.
 watch(
   () => app.model.outputs.datasetSize,
   (size) => {


### PR DESCRIPTION
Automatically switch to linear clustering for datasets with more than 1M rows

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR auto-selects the clustering algorithm based on dataset size: when the selected dataset exceeds 1 million rows, the UI switches `clusteringTool` to `easy-linclust` (linear-time); below the threshold it keeps `easy-cluster`. It also bumps several `@platforma-sdk` packages to 1.79.14.

**Key touched terms:**
- **`LARGE_DATASET_ROW_THRESHOLD`** — New exported constant (`1_000_000`). Defines the row-count boundary that triggers auto-selection of `easy-linclust` over `easy-cluster` in the UI watcher.
- **`datasetMatchers`** — Refactored in this PR from an inline literal to a module-private named constant, reused by the `datasetOptions` output and potentially by future outputs.
- **`datasetSize`** (output) — New `BlockModelV3` output returning `number | undefined`. Calls `getNumberOfRows(col.data)` on the selected column; returns `undefined` when no dataset is selected, the column isn't resolved yet, or the backing storage is non-parquet.
- **`clusteringTool`** (`BlockData` field) — Pre-existing `\"easy-cluster\" | \"easy-linclust\"` field. Now reactively auto-set by the new watcher in `MainPage.vue` based on `datasetSize`, while still being editable manually in Advanced Settings.
- **`getNumberOfRows`** — Newly imported SDK function. Reads parquet chunk statistics from column resource metadata without downloading blob data; the mechanism that makes `datasetSize` cheap to compute.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The change is small and well-scoped; the new watcher writes a bounded enum value, dependency bumps are in-lockstep, and the fallback (undefined size → no change) is correctly handled.

The auto-selection logic is sound, but there is a narrow window where a manual tool choice made while datasetSize is still resolving will be silently overridden once the value arrives. The JSDoc for LARGE_DATASET_ROW_THRESHOLD also references a non-existent symbol. Neither issue affects correctness for the common path, but the silent override could surprise users in slow-loading environments.

The watcher block in ui/src/pages/MainPage.vue (lines 92-99) and the JSDoc on LARGE_DATASET_ROW_THRESHOLD in model/src/index.ts are the only areas worth a second look before merging.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| model/src/index.ts | Adds LARGE_DATASET_ROW_THRESHOLD, extracts datasetMatchers constant, and introduces the datasetSize output; one stale JSDoc reference to a non-existent datasetSizeByRef symbol. |
| ui/src/pages/MainPage.vue | Adds a Vue watcher on datasetSize that auto-selects easy-linclust for large datasets; well-commented with a potential edge case where a manual tool choice made during data loading can be silently overridden. |
| pnpm-workspace.yaml | Bumps @platforma-sdk/model, @platforma-sdk/ui-vue, @platforma-sdk/test to 1.79.14 and @platforma-sdk/workflow-tengo to 6.6.3; straightforward dependency updates. |
| pnpm-lock.yaml | Lock file updated to reflect dependency version bumps; no manual edits, consistent with workspace catalog changes. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant MainPage as MainPage.vue
    participant BlockModel as BlockModel (datasetSize output)
    participant SDK as @platforma-sdk/model getNumberOfRows

    User->>MainPage: Selects dataset (PlDropdownRef)
    MainPage->>BlockModel: "data.datasetRef = inputRef (setInput)"
    BlockModel->>SDK: getNumberOfRows(col.data)
    SDK-->>BlockModel: "number | undefined (parquet chunk stats)"
    BlockModel-->>MainPage: outputs.datasetSize (reactive)
    MainPage->>MainPage: watch(datasetSize) fires
    alt "size === undefined (loading / non-parquet)"
        MainPage->>MainPage: leave clusteringTool unchanged
    else "size > LARGE_DATASET_ROW_THRESHOLD (1 000 000)"
        MainPage->>BlockModel: "data.clusteringTool = easy-linclust"
    else "size <= threshold"
        MainPage->>BlockModel: "data.clusteringTool = easy-cluster"
    end
    User->>MainPage: Manually overrides tool in Advanced Settings
    Note over MainPage,BlockModel: datasetSize unchanged - watcher silent - choice preserved
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant MainPage as MainPage.vue
    participant BlockModel as BlockModel (datasetSize output)
    participant SDK as @platforma-sdk/model getNumberOfRows

    User->>MainPage: Selects dataset (PlDropdownRef)
    MainPage->>BlockModel: "data.datasetRef = inputRef (setInput)"
    BlockModel->>SDK: getNumberOfRows(col.data)
    SDK-->>BlockModel: "number | undefined (parquet chunk stats)"
    BlockModel-->>MainPage: outputs.datasetSize (reactive)
    MainPage->>MainPage: watch(datasetSize) fires
    alt "size === undefined (loading / non-parquet)"
        MainPage->>MainPage: leave clusteringTool unchanged
    else "size > LARGE_DATASET_ROW_THRESHOLD (1 000 000)"
        MainPage->>BlockModel: "data.clusteringTool = easy-linclust"
    else "size <= threshold"
        MainPage->>BlockModel: "data.clusteringTool = easy-cluster"
    end
    User->>MainPage: Manually overrides tool in Advanced Settings
    Note over MainPage,BlockModel: datasetSize unchanged - watcher silent - choice preserved
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Amodel%2Fsrc%2Findex.ts%3A40-41%0A**Stale%20symbol%20in%20JSDoc%20comment**%0A%0AThe%20JSDoc%20says%20%60see%20%5C%60datasetSizeByRef%5C%60%20and%20%5C%60setInput%5C%60%60%20but%20%60datasetSizeByRef%60%20does%20not%20exist%20anywhere%20in%20the%20codebase.%20The%20actual%20implementation%20uses%20the%20%60datasetSize%60%20output%20%28declared%20three%20lines%20below%29%20and%20the%20%60watch%60%20in%20%60MainPage.vue%60.%20A%20developer%20following%20this%20reference%20will%20hit%20a%20dead%20end.%0A%0A%23%23%23%20Issue%202%20of%203%0Amodel%2Fsrc%2Findex.ts%3A40%0AThe%20JSDoc%20references%20%60datasetSizeByRef%60%20which%20doesn't%20exist%20%E2%80%94%20the%20actual%20output%20is%20named%20%60datasetSize%60.%0A%0A%60%60%60suggestion%0A%20*%20on%20dataset%20selection%20in%20the%20UI%20%E2%80%94%20see%20%60datasetSize%60%20output%20and%20the%20%60watch%60%20in%20%60MainPage.vue%60.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aui%2Fsrc%2Fpages%2FMainPage.vue%3A92-99%0A**Auto-selection%20can%20override%20a%20manual%20choice%20made%20while%20data%20is%20still%20loading**%0A%0AThe%20comment%20says%20%22a%20later%20manual%20choice%20in%20Advanced%20Settings%20is%20preserved%22%20%E2%80%94%20this%20is%20true%20once%20%60datasetSize%60%20has%20settled%2C%20because%20the%20watcher%20only%20fires%20on%20changes.%20However%2C%20if%20a%20user%20opens%20the%20settings%20panel%20and%20manually%20picks%20a%20tool%20before%20%60datasetSize%60%20resolves%20from%20%60undefined%60%20to%20a%20concrete%20number%20%28e.g.%2C%20first%20open%20of%20a%20block%20with%20a%20freshly-added%20dataset%29%2C%20the%20watcher%20will%20still%20fire%20when%20the%20value%20arrives%20and%20will%20overwrite%20that%20choice.%20The%20guard%20%60if%20%28size%20%3D%3D%3D%20undefined%29%20return%3B%60%20prevents%20writing%20on%20%60undefined%60%2C%20but%20it%20does%20not%20prevent%20overwriting%20a%20manual%20selection%20made%20in%20the%20window%20between%20dataset%20selection%20and%20data%20resolution.%0A%0A&repo=platforma-open%2Fclonotype-clustering&pr=127&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
model/src/index.ts:40-41
**Stale symbol in JSDoc comment**

The JSDoc says `see \`datasetSizeByRef\` and \`setInput\`` but `datasetSizeByRef` does not exist anywhere in the codebase. The actual implementation uses the `datasetSize` output (declared three lines below) and the `watch` in `MainPage.vue`. A developer following this reference will hit a dead end.

### Issue 2 of 3
model/src/index.ts:40
The JSDoc references `datasetSizeByRef` which doesn't exist — the actual output is named `datasetSize`.

```suggestion
 * on dataset selection in the UI — see `datasetSize` output and the `watch` in `MainPage.vue`.
```

### Issue 3 of 3
ui/src/pages/MainPage.vue:92-99
**Auto-selection can override a manual choice made while data is still loading**

The comment says "a later manual choice in Advanced Settings is preserved" — this is true once `datasetSize` has settled, because the watcher only fires on changes. However, if a user opens the settings panel and manually picks a tool before `datasetSize` resolves from `undefined` to a concrete number (e.g., first open of a block with a freshly-added dataset), the watcher will still fire when the value arrives and will overwrite that choice. The guard `if (size === undefined) return;` prevents writing on `undefined`, but it does not prevent overwriting a manual selection made in the window between dataset selection and data resolution.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["remove obvious comments"](https://github.com/platforma-open/clonotype-clustering/commit/ff58c40fbde1eaaa3b1809e0e25eeae952626d47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38626521)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->