### PR TITLE
SDK update

### DIFF
--- a/.changeset/common-ghosts-live.md
+++ b/.changeset/common-ghosts-live.md
@@ -1,0 +1,8 @@
+---
+"@platforma-open/milaboratories.clonotype-clustering.workflow": patch
+"@platforma-open/milaboratories.clonotype-clustering": patch
+"@platforma-open/milaboratories.clonotype-clustering.model": patch
+"@platforma-open/milaboratories.clonotype-clustering.ui": patch
+---
+
+SDK Update

--- a/.changeset/common-ghosts-live.md
+++ b/.changeset/common-ghosts-live.md
@@ -1,8 +1,0 @@
----
-"@platforma-open/milaboratories.clonotype-clustering.workflow": patch
-"@platforma-open/milaboratories.clonotype-clustering": patch
-"@platforma-open/milaboratories.clonotype-clustering.model": patch
-"@platforma-open/milaboratories.clonotype-clustering.ui": patch
----
-
-SDK Update

--- a/.changeset/light-bears-clap.md
+++ b/.changeset/light-bears-clap.md
@@ -1,6 +1,9 @@
 ---
 "@platforma-open/milaboratories.clonotype-clustering.workflow": patch
+"@platforma-open/milaboratories.clonotype-clustering": patch
 "@platforma-open/milaboratories.clonotype-clustering.model": patch
+"@platforma-open/milaboratories.clonotype-clustering.ui": patch
 ---
 
 Adapt clustering to new variant (dms) data
+SDK Update

--- a/.changeset/light-bears-clap.md
+++ b/.changeset/light-bears-clap.md
@@ -1,0 +1,6 @@
+---
+"@platforma-open/milaboratories.clonotype-clustering.workflow": patch
+"@platforma-open/milaboratories.clonotype-clustering.model": patch
+---
+
+Adapt clustering to new variant (dms) data

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,12 +24,11 @@ jobs:
     with:
       app-name: 'Block: Clonotype Clustering'
       app-name-slug: 'block-clonotype-clustering'
-
       node-version: '20.x'
       build-script-name: 'build'
       pnpm-recursive-build: false
 
-      test: false
+      test: true
       test-script-name: 'test'
       pnpm-recursive-tests: false
       team-id: 'ciplopen'
@@ -61,8 +60,8 @@ jobs:
           "QUAY_USERNAME": ${{ toJSON(secrets.QUAY_USERNAME) }},
           "QUAY_ROBOT_TOKEN": ${{ toJSON(secrets.QUAY_ROBOT_TOKEN) }} }
 
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_BLOCKS_CI_CHANNEL }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
 
       GH_ZEN_APP_ID: ${{ secrets.GH_ZEN_APP_ID }}
       GH_ZEN_APP_PRIVATE_KEY: ${{ secrets.GH_ZEN_APP_PRIVATE_KEY }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
       build-script-name: 'build'
       pnpm-recursive-build: false
 
-      test: true
+      test: false
       test-script-name: 'test'
       pnpm-recursive-tests: false
       team-id: 'ciplopen'

--- a/.github/workflows/mark-stable.yaml
+++ b/.github/workflows/mark-stable.yaml
@@ -30,5 +30,5 @@ jobs:
         { "NPMJS_TOKEN": ${{ toJSON(secrets.NPMJS_TOKEN) }},
           "AWS_CI_IAM_MONOREPO_SIMPLE_ROLE": ${{ toJSON(secrets.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE) }} }
 
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_CHANNEL: ${{ secrets.SLACK_BLOCKS_CI_CHANNEL }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/block/index.d.ts
+++ b/block/index.d.ts
@@ -1,6 +1,0 @@
-declare const blockSpec: {
-  type: "dev-v2";
-  folder: string;
-};
-
-export { blockSpec };

--- a/block/index.js
+++ b/block/index.js
@@ -1,8 +1,0 @@
-const blockSpec = {
-  type: "dev-v2",
-  folder: __dirname,
-};
-
-module.exports = {
-  blockSpec,
-};

--- a/block/package.json
+++ b/block/package.json
@@ -2,23 +2,37 @@
   "name": "@platforma-open/milaboratories.clonotype-clustering",
   "version": "3.2.1",
   "files": [
-    "index.d.ts",
-    "index.js"
+    "dist",
+    "block-pack"
   ],
-  "scripts": {
-    "build": "shx rm -rf ./block-pack && block-tools pack",
-    "do-pack": "shx rm -f *.tgz && block-tools pack && pnpm pack && shx mv *.tgz package.tgz",
-    "mark-stable": "block-tools mark-stable -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'",
-    "prepublishOnly": "block-tools pack && block-tools publish -r 's3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1'"
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "sources": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
   },
-  "dependencies": {
+  "scripts": {
+    "build": "ts-builder build --target block-facade && block-tools pack",
+    "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
+    "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://blocks.pl-open.science",
+    "check": "ts-builder type-check --target block-facade"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@milaboratories/ts-builder": "catalog:",
+    "@milaboratories/ts-configs": "catalog:",
     "@platforma-open/milaboratories.clonotype-clustering.model": "workspace:*",
     "@platforma-open/milaboratories.clonotype-clustering.ui": "workspace:*",
-    "@platforma-open/milaboratories.clonotype-clustering.workflow": "workspace:*"
-  },
-  "devDependencies": {
+    "@platforma-open/milaboratories.clonotype-clustering.workflow": "workspace:*",
     "@platforma-sdk/block-tools": "catalog:",
-    "shx": "catalog:"
+    "@platforma-sdk/model": "catalog:",
+    "shx": "catalog:",
+    "typescript": "catalog:"
   },
   "packageManager": "pnpm@9.14.4",
   "block": {

--- a/block/src/AGENTS.ts
+++ b/block/src/AGENTS.ts
@@ -1,0 +1,5 @@
+// This file is managed by `block-tools structure`. Do not edit by hand.
+// Narrow MCP / AI surface.
+
+export type { BlockContract, BlockOutputs, BlockData } from "./index";
+export * from "./agents-extra";

--- a/block/src/agents-extra.ts
+++ b/block/src/agents-extra.ts
@@ -1,0 +1,8 @@
+// Author-owned. `block-tools structure` does not modify this file.
+// MCP / AI extension surface. Add types and functions the agent
+// surface should expose.
+//
+// In the future this file will host JS functions the MCP runtime
+// can execute. The `.d.ts` declarations stay visible to the agent;
+// the JS bodies execute in the MCP code-execution context (the
+// agent sees the types but not the implementation).

--- a/block/src/block-extra.ts
+++ b/block/src/block-extra.ts
@@ -1,0 +1,9 @@
+// Author-owned. `block-tools structure` does not modify this file.
+// Add block-specific helper types or values the consumer surface
+// should expose. Anything you `export` here flows out via the
+// main entry (./index re-exports this file).
+//
+// Do NOT redefine: BlockContract, BlockOutputs, BlockData,
+// BlockPointer, platforma, or the block-named <PascalName>Block*
+// aliases — those names come from ./index and `export *` from this
+// file would shadow them.

--- a/block/src/index.ts
+++ b/block/src/index.ts
@@ -1,0 +1,55 @@
+// This file is managed by `block-tools structure`. Do not edit by hand.
+// Author content lives in ./block-extra.ts.
+
+import { platforma } from "@platforma-open/milaboratories.clonotype-clustering.model";
+import {
+  InferOutputsType,
+  InferDataType,
+  InferHrefType,
+} from "@platforma-sdk/model";
+
+export { platforma };
+
+export type BlockContract = {
+  outputs: InferOutputsType<typeof platforma>;
+  data:    InferDataType<typeof platforma>;
+  href:    InferHrefType<typeof platforma>;
+};
+
+export type BlockOutputs = BlockContract["outputs"];
+export type BlockData    = BlockContract["data"];
+
+// import.meta.url is a file: URL (always forward-slash, even on Windows:
+// file:///C:/…). We expose URLs, NOT paths — the facade stays dependency-free
+// and loadable in minimal engines (e.g. QuickJS), and each consumer converts
+// at its own edge with the right tool (fileURLToPath in Node), where Windows
+// drive letters / %-encoding / UNC are handled correctly. The bundled entry
+// sits one dir under the package root (dist/index.js, or src/index.ts in dev),
+// so the root is two URL segments up. The structurer owns this layout —
+// consumers read these URLs, they never reconstruct <root>/block-pack.
+//
+// TypeScript ships `ImportMeta.url` only in the `dom`/`webworker` libs; the
+// facade tsconfig is lib-minimal (no `dom`, no `@types/node`) by design. We
+// type the one ESM-standard member we use with a local cast rather than a
+// `declare global` — a global augmentation would leak into the published
+// `dist/index.d.ts` and clash with `@types/node`'s `ImportMeta` in full-Node
+// consumers (test packages, the Middle Layer).
+const selfUrl = (import.meta as ImportMeta & { url: string }).url;
+const dirUrl  = selfUrl.slice(0, selfUrl.lastIndexOf("/"));
+const rootUrl = dirUrl.slice(0, dirUrl.lastIndexOf("/"));
+
+export const BlockPointer = {
+  type: "from-pack-v2" as const,
+  packUrl: rootUrl + "/block-pack",
+  rootUrl,
+} as const;
+
+// Block-named aliases for readable cross-block imports in tests and
+// consumer code. Same types / same runtime value as the universal
+// names above; the aliases avoid `as`-renames at the import site.
+export type ClonotypeClusteringBlockContract = BlockContract;
+export type ClonotypeClusteringBlockOutputs  = BlockOutputs;
+export type ClonotypeClusteringBlockData     = BlockData;
+export const ClonotypeClusteringBlockPointer = BlockPointer;
+
+export * from "./block-extra";

--- a/block/tsconfig.json
+++ b/block/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@milaboratories/ts-configs/block/facade",
+  "include": ["src/**/*"]
+}

--- a/model/package.json
+++ b/model/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.clonotype-clustering.model",
   "version": "3.2.1",
+  "private": true,
   "description": "Block model",
   "type": "module",
   "main": "dist/index.cjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,7 +104,13 @@ importers:
         version: 5.6.3
 
   block:
-    dependencies:
+    devDependencies:
+      '@milaboratories/ts-builder':
+        specifier: 'catalog:'
+        version: 1.6.0(@types/node@24.5.2)(rollup@4.53.5)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.1)
+      '@milaboratories/ts-configs':
+        specifier: 'catalog:'
+        version: 1.3.0
       '@platforma-open/milaboratories.clonotype-clustering.model':
         specifier: workspace:*
         version: link:../model
@@ -114,13 +120,18 @@ importers:
       '@platforma-open/milaboratories.clonotype-clustering.workflow':
         specifier: workspace:*
         version: link:../workflow
-    devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
         version: 2.11.6(@types/node@24.5.2)
+      '@platforma-sdk/model':
+        specifier: 'catalog:'
+        version: 1.79.20
       shx:
         specifier: 'catalog:'
         version: 0.4.0
+      typescript:
+        specifier: 'catalog:'
+        version: 5.6.3
 
   model:
     dependencies:
@@ -1266,12 +1277,6 @@ packages:
 
   '@milaboratories/uikit@2.15.11':
     resolution: {integrity: sha512-oBQiPXpHEwg1dLptfCQNtpRrJ3stunjrTWiP5U90rAXl4c6Z/Ks7YU/fVvoqdBsoSBQ6nEcAG0Sk4sV8DVRlJQ==}
-
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -3702,9 +3707,6 @@ packages:
     resolution: {integrity: sha512-RLGFxPNgY9AtVVrFGdKO6Y3pOd/Ov2WA4O2/czZN/AbgYzbPdoF0KkfvHRIney6k+TtvoyYB8YqZXJ4G88f9BQ==}
     engines: {node: '>=0.10.0', npm: '>2.7.0'}
     os: [aix, darwin, freebsd, linux, macos, openbsd, sunos, win32, windows]
-
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
@@ -8197,11 +8199,11 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
@@ -8793,7 +8795,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.3':
@@ -11356,11 +11358,6 @@ snapshots:
     dependencies:
       '@stdlib/utils-constructor-name': 0.2.2
       '@stdlib/utils-global': 0.2.2
-
-  '@tybys/wasm-util@0.10.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@tybys/wasm-util@0.10.3':
     dependencies:

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.clonotype-clustering.ui",
   "version": "4.2.1",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "ts-builder serve --target block-ui",

--- a/workflow/package.json
+++ b/workflow/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@platforma-open/milaboratories.clonotype-clustering.workflow",
   "version": "4.2.1",
+  "private": true,
   "description": "Tengo-based template",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades the block facade to the new SDK package structure, replacing hand-written `index.js`/`index.d.ts` files with a TypeScript source tree managed by `block-tools structure` and `ts-builder`. Internal packages (`model`, `ui`, `workflow`) are marked `private: true`, while the root block package gains proper ESM exports and a generated type surface.

- **Block façade refactor**: `block/index.js` and `block/index.d.ts` are deleted and replaced with `block/src/index.ts` (auto-generated scaffold), `block-extra.ts` and `agents-extra.ts` (author-owned stubs), and a `tsconfig.json` that extends the new shared `block/facade` config. Runtime block location is now resolved via `import.meta.url` rather than `__dirname`.
- **Package structure alignment**: `model`, `ui`, and `workflow` gain `"private": true`; workspace siblings move from `dependencies` to `devDependencies` in the block package; `@platforma-sdk/model` is added as a dev dependency to support the new type inference.
- **CI improvements**: tests are re-enabled (`test: true`) in `build.yaml`, and minor ordering fixes are applied to secret variables in both workflow files.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

This PR is safe to merge; the changes are a straightforward SDK-prescribed scaffold migration with no behavioral regressions in the production build path.

The core façade logic — BlockContract, BlockPointer, and the import.meta.url-based URL computation — is clean and well-commented. The do-pack script loses its pre-cleanup step, which could cause a confusing failure in local dev if stale .tgz files exist, but has no effect on CI. The light-bears-clap changeset carries a description that does not match the diff, which will create a misleading changelog entry. Neither issue affects runtime behavior or the published package.

.changeset/light-bears-clap.md has a description that does not match the changes in this PR. block/package.json's do-pack script and the depth assumption in block/src/index.ts are worth a second look.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| block/src/index.ts | Auto-generated facade entry; exports BlockContract/Outputs/Data/Pointer types and runtime URL via import.meta.url. URL root computation (two lastIndexOf slices) is correct for dist/index.js depth but breaks if ts-builder nests output deeper than one level. |
| block/package.json | Major restructure: workspace siblings moved from dependencies to devDependencies, empty runtime dependencies, new ESM exports map, build script now uses ts-builder. The do-pack script drops the pre-existing *.tgz cleanup step. |
| block/src/AGENTS.ts | Thin MCP/AI surface scaffold; re-exports type-only symbols from index.ts and the empty agents-extra.ts stub. No logic, safe as-is. |
| block/src/agents-extra.ts | Empty author-owned stub for MCP/agent surface extensions; only contains documentation comments. |
| block/src/block-extra.ts | Empty author-owned stub for block-specific helper exports; only contains documentation comments. |
| block/tsconfig.json | Minimal tsconfig extending the shared block/facade preset; straightforward addition. |
| model/package.json | Adds private: true so the model package is no longer published independently to npm; all other fields unchanged. |
| ui/package.json | Adds private: true so the ui package is no longer published independently; no other changes. |
| workflow/package.json | Adds private: true so the workflow package is no longer published independently; no other changes. |
| .github/workflows/build.yaml | Re-enables the test step (test: true) and reorders SLACK secret variables; minor but correct change. |
| .github/workflows/mark-stable.yaml | Reorders SLACK_CHANNEL and SLACK_BOT_TOKEN variables and adds a missing newline at end of file. |
| .changeset/light-bears-clap.md | Declares a patch bump for workflow and model citing 'Adapt clustering to new variant (dms) data', but no corresponding workflow or model source changes are present in this PR's diff. |
| .changeset/common-ghosts-live.md | Patch bump for all four packages; accurately reflects the SDK update changes in this PR. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Published ["Published Package"]
        B["@platforma-open/…clonotype-clustering\n(block/package.json)\ndist/ + block-pack/"]
    end

    subgraph PrivateWorkspace ["Private Workspace Packages (private: true)"]
        M["model\n@platforma-open/….model\nprovides: platforma, model.json"]
        U["ui\n@platforma-open/….ui\nprovides: dist/"]
        W["workflow\n@platforma-open/….workflow\nprovides: dist/tengo/tpl/main.plj.gz"]
    end

    subgraph BlockSrc ["block/src (auto-managed by block-tools)"]
        IDX["index.ts\n→ BlockContract, BlockOutputs,\n  BlockData, BlockPointer\n  (via import.meta.url)\n  ClonotypeClusteringBlock* aliases"]
        AGT["AGENTS.ts\n→ narrow MCP/AI surface\n  (types only)"]
        AGEX["agents-extra.ts\n(author stub)"]
        BLEX["block-extra.ts\n(author stub)"]
    end

    M -->|"InferOutputsType / InferDataType / InferHrefType\n(devDep, inlined at build)"| IDX
    IDX --> AGT
    AGEX --> AGT
    BLEX -->|"export *"| IDX

    IDX -->|"ts-builder build"| B
    M -->|"block-tools pack → model.json"| B
    U -->|"block-tools pack → dist/"| B
    W -->|"block-tools pack → main.plj.gz"| B

    B -->|"BlockPointer.packUrl\n(import.meta.url-based URL)"| Consumer["Consumer packages\n(Middle Layer / tests)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph Published ["Published Package"]
        B["@platforma-open/…clonotype-clustering\n(block/package.json)\ndist/ + block-pack/"]
    end

    subgraph PrivateWorkspace ["Private Workspace Packages (private: true)"]
        M["model\n@platforma-open/….model\nprovides: platforma, model.json"]
        U["ui\n@platforma-open/….ui\nprovides: dist/"]
        W["workflow\n@platforma-open/….workflow\nprovides: dist/tengo/tpl/main.plj.gz"]
    end

    subgraph BlockSrc ["block/src (auto-managed by block-tools)"]
        IDX["index.ts\n→ BlockContract, BlockOutputs,\n  BlockData, BlockPointer\n  (via import.meta.url)\n  ClonotypeClusteringBlock* aliases"]
        AGT["AGENTS.ts\n→ narrow MCP/AI surface\n  (types only)"]
        AGEX["agents-extra.ts\n(author stub)"]
        BLEX["block-extra.ts\n(author stub)"]
    end

    M -->|"InferOutputsType / InferDataType / InferHrefType\n(devDep, inlined at build)"| IDX
    IDX --> AGT
    AGEX --> AGT
    BLEX -->|"export *"| IDX

    IDX -->|"ts-builder build"| B
    M -->|"block-tools pack → model.json"| B
    U -->|"block-tools pack → dist/"| B
    W -->|"block-tools pack → main.plj.gz"| B

    B -->|"BlockPointer.packUrl\n(import.meta.url-based URL)"| Consumer["Consumer packages\n(Middle Layer / tests)"]
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0A.changeset%2Flight-bears-clap.md%3A1-6%0A**Changeset%20description%20doesn't%20match%20the%20diff**%0A%0AThis%20changeset%20says%20%22Adapt%20clustering%20to%20new%20variant%20%28dms%29%20data%22%20and%20bumps%20both%20%60workflow%60%20and%20%60model%60%2C%20but%20neither%20package%20has%20any%20source-level%20changes%20in%20this%20PR%20%E2%80%94%20only%20%60%22private%22%3A%20true%60%20was%20added%20to%20each%20%60package.json%60.%20If%20the%20DMS%20adaptation%20changes%20were%20already%20merged%20separately%2C%20the%20changeset%20description%20should%20reflect%20what%20this%20PR%20actually%20contributes%20%28e.g.%20%22Mark%20workflow%20and%20model%20as%20private%20workspace%20packages%22%29.%20A%20misleading%20changeset%20description%20makes%20the%20generated%20%60CHANGELOG.md%60%20entry%20harder%20to%20understand.%0A%0A%23%23%23%20Issue%202%20of%203%0Ablock%2Fsrc%2Findex.ts%3A37-39%0A**%60rootUrl%60%20computation%20assumes%20exactly%20one%20directory%20level%20between%20package%20root%20and%20the%20bundle%20entry**%0A%0AThe%20code%20strips%20two%20path%20segments%20from%20%60import.meta.url%60%20%28file%20%E2%86%92%20dir%2C%20dir%20%E2%86%92%20root%29.%20This%20is%20documented%20as%20intentional%20%28%22sits%20one%20dir%20under%20the%20package%20root%22%29%2C%20but%20if%20%60ts-builder%60%20ever%20emits%20to%20a%20nested%20output%20like%20%60dist%2Fesm%2Findex.js%60%2C%20%60rootUrl%60%20would%20resolve%20to%20%60dist%2F%60%20instead%20of%20the%20package%20root%2C%20making%20%60packUrl%60%20%28%60dist%2Fblock-pack%60%29%20silently%20wrong.%20Consider%20asserting%20or%20documenting%20in%20the%20tsconfig%20%2F%20build%20script%20that%20the%20output%20depth%20must%20remain%20exactly%20one%20level%20%28e.g.%20%60dist%2Findex.js%60%29%2C%20so%20future%20tooling%20changes%20don't%20break%20this%20silently.%0A%0A%23%23%23%20Issue%203%20of%203%0Ablock%2Fpackage.json%3A21%0A**%60do-pack%60%20missing%20pre-cleanup%20of%20existing%20%60.tgz%60%20files**%0A%0AThe%20old%20script%20started%20with%20%60shx%20rm%20-f%20*.tgz%60%20before%20packing.%20The%20new%20script%20goes%20straight%20to%20%60pnpm%20pack%20%26%26%20shx%20mv%20*.tgz%20package.tgz%60.%20If%20a%20%60package.tgz%60%20or%20any%20other%20%60.tgz%60%20file%20already%20exists%20in%20the%20directory%20%28e.g.%20from%20a%20prior%20run%29%2C%20the%20glob%20%60*.tgz%60%20will%20match%20multiple%20files%20and%20%60shx%20mv%60%20will%20fail%20or%20silently%20pick%20the%20wrong%20one%2C%20leaving%20the%20directory%20in%20a%20bad%20state.%20Adding%20%60shx%20rm%20-f%20*.tgz%60%20back%20before%20%60pnpm%20pack%60%20would%20restore%20the%20safe%20baseline.%0A%0A&repo=platforma-open%2Fclonotype-clustering&pr=129&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
.changeset/light-bears-clap.md:1-6
**Changeset description doesn't match the diff**

This changeset says "Adapt clustering to new variant (dms) data" and bumps both `workflow` and `model`, but neither package has any source-level changes in this PR — only `"private": true` was added to each `package.json`. If the DMS adaptation changes were already merged separately, the changeset description should reflect what this PR actually contributes (e.g. "Mark workflow and model as private workspace packages"). A misleading changeset description makes the generated `CHANGELOG.md` entry harder to understand.

### Issue 2 of 3
block/src/index.ts:37-39
**`rootUrl` computation assumes exactly one directory level between package root and the bundle entry**

The code strips two path segments from `import.meta.url` (file → dir, dir → root). This is documented as intentional ("sits one dir under the package root"), but if `ts-builder` ever emits to a nested output like `dist/esm/index.js`, `rootUrl` would resolve to `dist/` instead of the package root, making `packUrl` (`dist/block-pack`) silently wrong. Consider asserting or documenting in the tsconfig / build script that the output depth must remain exactly one level (e.g. `dist/index.js`), so future tooling changes don't break this silently.

### Issue 3 of 3
block/package.json:21
**`do-pack` missing pre-cleanup of existing `.tgz` files**

The old script started with `shx rm -f *.tgz` before packing. The new script goes straight to `pnpm pack && shx mv *.tgz package.tgz`. If a `package.tgz` or any other `.tgz` file already exists in the directory (e.g. from a prior run), the glob `*.tgz` will match multiple files and `shx mv` will fail or silently pick the wrong one, leaving the directory in a bad state. Adding `shx rm -f *.tgz` back before `pnpm pack` would restore the safe baseline.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["SDK update"](https://github.com/platforma-open/clonotype-clustering/commit/723023bf573459cd44f403dd4ea4532f727cfa7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40869789)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->