### PR TITLE
MILAB-6582: fix singleton reassignment 2^32 crash in high-precision c…

### DIFF
--- a/.changeset/milab-6582-reassign-oom-fix.md
+++ b/.changeset/milab-6582-reassign-oom-fix.md
@@ -1,0 +1,15 @@
+---
+"@platforma-open/milaboratories.clonotype-clustering.software": patch
+---
+
+MILAB-6582: fix singleton reassignment crash on large repertoires. High-precision
+mode's reassignment cross-joined every singleton with every non-singleton centroid,
+materializing n_singletons × n_centroids rows and overflowing polars' 2^32 row limit
+(`ComputeError: cross joins would produce more rows than fits into 2^32`).
+
+Replaced the all-pairs cross join with a per-centroid length-band prefilter +
+bounded `filter_by_levenshtein` + exact recheck, keeping only a running
+best-per-singleton (periodic reduction). Peak memory is now O(#singletons)
+regardless of match density, and no cross join is built. The reassignment result
+(closest centroid, then largest cluster) is identical to before, covered by the
+added reassignment regression tests.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch: {}
 jobs:
   init:
-    runs-on: ubuntu-latest
+    runs-on: hz-ubuntu-dind
     steps:
       - uses: milaboratory/github-ci/actions/context/init@v4
         with:
@@ -25,10 +25,12 @@ jobs:
       app-name: 'Block: Clonotype Clustering'
       app-name-slug: 'block-clonotype-clustering'
       node-version: '20.x'
-      build-script-name: 'build'
+      gha-runner-label: hz-ubuntu-dind
+      build-script-name: 'build:dev-local'
+      build-before-publish-script-name: 'build:release'
       pnpm-recursive-build: false
 
-      test: false
+      test: true
       test-script-name: 'test'
       pnpm-recursive-tests: false
       team-id: 'ciplopen'
@@ -56,6 +58,15 @@ jobs:
 
           "AWS_CI_IAM_MONOREPO_SIMPLE_ROLE": ${{ toJSON(secrets.AWS_CI_IAM_MONOREPO_SIMPLE_ROLE) }},
           "AWS_CI_TURBOREPO_S3_BUCKET": ${{ toJSON(secrets.AWS_CI_TURBOREPO_S3_BUCKET) }},
+
+          "HZ_CI_TURBO_S3_BUCKET": ${{ toJSON(vars.HZ_CI_TURBO_S3_BUCKET) }},
+          "HZ_CI_TURBO_S3_ENDPOINT": ${{ toJSON(vars.HZ_CI_TURBO_S3_ENDPOINT) }},
+          "HZ_CI_TURBO_S3_REGION": ${{ toJSON(vars.HZ_CI_TURBO_S3_REGION) }},
+          "HZ_CI_TURBO_S3_ACCESS_KEY": ${{ toJSON(secrets.HZ_CI_TURBO_S3_ACCESS_KEY) }},
+          "HZ_CI_TURBO_S3_SECRET_KEY": ${{ toJSON(secrets.HZ_CI_TURBO_S3_SECRET_KEY) }},
+          "HZ_CI_CACHE_S3_ACCESS_KEY": ${{ toJSON(secrets.HZ_CI_CACHE_S3_ACCESS_KEY) }},
+          "HZ_CI_CACHE_S3_SECRET_KEY": ${{ toJSON(secrets.HZ_CI_CACHE_S3_SECRET_KEY) }},
+
           "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL": ${{ toJSON(secrets.PL_REGISTRY_PLOPEN_UPLOAD_URL) }},
           "QUAY_USERNAME": ${{ toJSON(secrets.QUAY_USERNAME) }},
           "QUAY_ROBOT_TOKEN": ${{ toJSON(secrets.QUAY_ROBOT_TOKEN) }} }

--- a/.github/workflows/python-tests.yaml
+++ b/.github/workflows/python-tests.yaml
@@ -1,0 +1,33 @@
+name: Python Tests
+
+on:
+  merge_group:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - 'main'
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch: {}
+
+jobs:
+  pytest:
+    if: github.repository != 'milaboratory/platforma-clonotype-clustering'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: software
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: software/uv.lock
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Run pytest
+        run: uv run pytest

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ software/**/*.tgz
 # Python
 __pycache__/
 *.pyc
+.venv/
+**/.pytest_cache/
+**/.ruff_cache/

--- a/.structure
+++ b/.structure
@@ -1,1 +1,1 @@
-{"version":1}
+{"version":2}

--- a/block/package.json
+++ b/block/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "build": "ts-builder build --target block-facade && block-tools pack",
-    "do-pack": "pnpm pack && shx mv *.tgz package.tgz",
+    "do-pack": "shx rm -f package.tgz && pnpm pack && shx mv *.tgz package.tgz",
     "prepublishOnly": "block-tools publish -r s3://milab-euce1-prod-pkgs-s3-block-registry/pub/releases/?region=eu-central-1 --registry-serve-url https://blocks.pl-open.science",
     "check": "ts-builder type-check --target block-facade"
   },

--- a/model/package.json
+++ b/model/package.json
@@ -19,7 +19,6 @@
     "build": "ts-builder build --target block-model && block-tools build-model",
     "watch": "ts-builder build --target block-model --watch",
     "type-check": "ts-builder type-check --target block-model",
-    "test": "vitest",
     "do-pack": "shx rm -f *.tgz && pnpm pack && shx mv *.tgz package.tgz",
     "fmt": "ts-builder format",
     "check": "ts-builder check --target block-model"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,9 @@
 {
   "scripts": {
-    "build": "turbo run build",
-    "build:dev": "env PL_PKG_DEV=local turbo run build",
     "lint": "turbo run lint",
     "type-check": "turbo run type-check",
-    "test": "env PL_PKG_DEV=local turbo run test --concurrency 1",
-    "test:dry-run": "env PL_PKG_DEV=local turbo run test --dry-run=json",
+    "test": "env PL_BUILD_CHANNEL=dev PL_BUILD_VARIANT=binary PL_BUILD_LOCATION=local turbo run test --concurrency 1",
+    "test:dry-run": "env PL_BUILD_CHANNEL=dev PL_BUILD_VARIANT=binary PL_BUILD_LOCATION=local turbo run test --dry-run=json",
     "mark-stable": "turbo run mark-stable",
     "do-pack": "turbo run do-pack",
     "watch": "turbo watch build",
@@ -14,7 +12,12 @@
     "update-sdk": "block-tools structure refresh --update-deps-only",
     "fmt": "turbo run fmt",
     "check": "turbo run check",
-    "upgrade-sdk": "block-tools structure refresh --update-deps-only && pnpm i && block-tools structure refresh && pnpm i && pnpm fmt"
+    "upgrade-sdk": "block-tools structure refresh --update-deps-only && pnpm i && block-tools structure refresh && pnpm i && pnpm fmt",
+    "build:dev-local": "env PL_BUILD_CHANNEL=dev PL_BUILD_VARIANT=all PL_BUILD_LOCATION=local turbo run build",
+    "build:dev-remote": "env PL_BUILD_CHANNEL=dev PL_BUILD_VARIANT=all PL_BUILD_LOCATION=remote turbo run build",
+    "build:dev-no-software": "env PL_BUILD_CHANNEL=dev PL_BUILD_VARIANT=none turbo run build",
+    "build:dev-binary-existing": "env PL_BUILD_CHANNEL=dev PL_BUILD_USE_PUBLISHED=true turbo run build",
+    "build:release": "env PL_BUILD_CHANNEL=release PL_BUILD_VARIANT=all PL_BUILD_LOCATION=remote turbo run build"
   },
   "devDependencies": {
     "@changesets/cli": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ catalogs:
       specifier: 1.4.6
       version: 1.4.6
     '@milaboratories/helpers':
-      specifier: 1.14.2
-      version: 1.14.2
+      specifier: 1.14.3
+      version: 1.14.3
     '@milaboratories/multi-sequence-alignment':
       specifier: 1.47.16
       version: 1.47.16
@@ -137,7 +137,7 @@ importers:
         version: 1.4.6(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)(@platforma-sdk/ui-vue@1.79.27(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@milaboratories/helpers':
         specifier: 'catalog:'
-        version: 1.14.2
+        version: 1.14.3
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -7765,7 +7765,7 @@ snapshots:
   '@milaboratories/graph-maker@1.4.6(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)(@platforma-sdk/ui-vue@1.79.27(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.5
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': 1.14.3
       '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
       '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)
       '@platforma-sdk/model': 1.79.27
@@ -7861,7 +7861,7 @@ snapshots:
 
   '@milaboratories/pf-plots@1.4.4(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': 1.14.3
       '@milaboratories/pl-model-common': 1.46.4
       '@platforma-sdk/model': 1.79.27
       canonicalize: 2.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,26 +34,23 @@ catalogs:
       specifier: 1.18.0
       version: 1.18.0
     '@platforma-sdk/block-tools':
-      specifier: 2.11.6
-      version: 2.11.6
+      specifier: 2.12.2
+      version: 2.12.2
     '@platforma-sdk/model':
-      specifier: 1.79.20
-      version: 1.79.20
-    '@platforma-sdk/package-builder':
-      specifier: 3.14.0
-      version: 3.14.0
+      specifier: 1.79.27
+      version: 1.79.27
     '@platforma-sdk/tengo-builder':
-      specifier: 4.0.11
-      version: 4.0.11
+      specifier: 4.0.15
+      version: 4.0.15
     '@platforma-sdk/test':
-      specifier: 1.79.23
-      version: 1.79.23
+      specifier: 1.79.31
+      version: 1.79.31
     '@platforma-sdk/ui-vue':
-      specifier: 1.79.20
-      version: 1.79.20
+      specifier: 1.79.27
+      version: 1.79.27
     '@platforma-sdk/workflow-tengo':
-      specifier: 6.6.5
-      version: 6.6.5
+      specifier: 6.7.0
+      version: 6.7.0
     eslint:
       specifier: ^9.25.1
       version: 9.39.2
@@ -92,7 +89,7 @@ importers:
         version: 1.6.0(@types/node@24.5.2)(rollup@4.53.5)(vue@3.5.25(typescript@5.6.3))(yaml@2.8.1)
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.11.6(@types/node@24.5.2)
+        version: 2.12.2(@types/node@24.5.2)
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -122,10 +119,10 @@ importers:
         version: link:../workflow
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.11.6(@types/node@24.5.2)
+        version: 2.12.2(@types/node@24.5.2)
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.20
+        version: 1.79.27
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -137,7 +134,7 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.6(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.20)(@platforma-sdk/ui-vue@1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.4.6(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)(@platforma-sdk/ui-vue@1.79.27(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@milaboratories/helpers':
         specifier: 'catalog:'
         version: 1.14.2
@@ -146,7 +143,7 @@ importers:
         version: 0.1.2
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.20
+        version: 1.79.27
       '@types/node':
         specifier: '*'
         version: 24.5.2
@@ -162,7 +159,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.11.6(@types/node@24.5.2)
+        version: 2.12.2(@types/node@24.5.2)
       eslint:
         specifier: 'catalog:'
         version: 9.39.2
@@ -172,9 +169,9 @@ importers:
       '@platforma-open/milaboratories.runenv-python-3':
         specifier: 'catalog:'
         version: 1.10.3
-      '@platforma-sdk/package-builder':
+      '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 3.14.0
+        version: 2.12.2(@types/node@24.5.2)
 
   test:
     dependencies:
@@ -193,7 +190,7 @@ importers:
         version: 1.3.0
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.23(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.3.5(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1))
+        version: 1.79.31(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.3.5(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1))
       eslint:
         specifier: 'catalog:'
         version: 9.39.2
@@ -205,10 +202,10 @@ importers:
     dependencies:
       '@milaboratories/graph-maker':
         specifier: 'catalog:'
-        version: 1.4.6(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.20)(@platforma-sdk/ui-vue@1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.4.6(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)(@platforma-sdk/ui-vue@1.79.27(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@milaboratories/multi-sequence-alignment':
         specifier: 'catalog:'
-        version: 1.47.16(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.20)(@platforma-sdk/ui-vue@1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
+        version: 1.47.16(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)(@platforma-sdk/ui-vue@1.79.27(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)
       '@milaboratories/strings':
         specifier: 'catalog:'
         version: 0.1.2
@@ -217,10 +214,10 @@ importers:
         version: link:../model
       '@platforma-sdk/model':
         specifier: 'catalog:'
-        version: 1.79.20
+        version: 1.79.27
       '@platforma-sdk/ui-vue':
         specifier: 'catalog:'
-        version: 1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+        version: 1.79.27(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@types/node':
         specifier: '*'
         version: 24.5.2
@@ -251,14 +248,14 @@ importers:
         version: 1.18.0
       '@platforma-sdk/workflow-tengo':
         specifier: 'catalog:'
-        version: 6.6.5
+        version: 6.7.0
     devDependencies:
       '@platforma-sdk/tengo-builder':
         specifier: 'catalog:'
-        version: 4.0.11
+        version: 4.0.15
       '@platforma-sdk/test':
         specifier: 'catalog:'
-        version: 1.79.23(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
+        version: 1.79.31(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
       shx:
         specifier: 'catalog:'
         version: 0.4.0
@@ -348,6 +345,10 @@ packages:
 
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-ecr-public@3.859.0':
+    resolution: {integrity: sha512-pPY85lrGBNWynofNC6Er49W6aA4JvOOKC9RDbS8rWR8pBPEG6p0B82VQKFMR+3JYRogpfQf5hzU47um96EslFA==}
+    engines: {node: '>=18.0.0'}
 
   '@aws-sdk/client-s3@3.859.0':
     resolution: {integrity: sha512-oFLHZX1X6o54ZlweubtSVvQDz15JiNrgDD7KeMZT2MwxiI3axPcHzTo2uizjj5mgNapmYjRmQS5c1c63dvruVA==}
@@ -1146,8 +1147,8 @@ packages:
   '@milaboratories/biowasm-tools@2.0.3':
     resolution: {integrity: sha512-/X2PJ9VYmVKHZ12X7p2lgzEN+zqeycatVGdVA1ifsdBXE4bKNmCrWhUr4JRlpoB5wuj/J5chBbIi6N9y6Tk1aw==}
 
-  '@milaboratories/computable@2.9.5':
-    resolution: {integrity: sha512-rzLJ6fjXcNL8jb6vexGR4d8wUGvrwC2CyjkMLU5GFy+7Q6lg1wTrJnu8fzDVhS2OjEEVbD+RTE7AGvK5pYYSMQ==}
+  '@milaboratories/computable@2.9.6':
+    resolution: {integrity: sha512-Au+84jboSJMM2k39mWUFCtPl2wkislD1fLbb45du1PcAg1GSER1ThSLoBpZUQC2oiTt804WmbzhZ2yaoVZiVLQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/graph-maker@1.4.6':
@@ -1160,6 +1161,10 @@ packages:
     resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
     engines: {node: '>=22'}
 
+  '@milaboratories/helpers@1.14.3':
+    resolution: {integrity: sha512-nZv+n+orVzA/GimDTNj6Yjb52+Wu5f/Kf2z6UCGXni6KTquLBfQhi3AFB1mLE7hkUYPvKU6LxuRY02CQMQiTVA==}
+    engines: {node: '>=22'}
+
   '@milaboratories/miplots4@1.2.2':
     resolution: {integrity: sha512-VMdMxfD/lwObssvYDFRnBcBAV4JFqI2FsoQqmJ/wurIHieoZLU9K0UO57MvsvtmO3Deb9swUjuDUJ+jAe8isqw==}
 
@@ -1169,8 +1174,8 @@ packages:
       '@platforma-sdk/model': 1.73.3
       '@platforma-sdk/ui-vue': 1.73.3
 
-  '@milaboratories/pf-driver@1.7.14':
-    resolution: {integrity: sha512-JRuMmuhObyD27MtpCcimGklr2yMJ2PobcYJ2y5k+UuhQWXKllhEDlUAyv2Xw/I7Xxym8Nn2npcVdOaJvTP3bPA==}
+  '@milaboratories/pf-driver@1.7.16':
+    resolution: {integrity: sha512-yujIUylT11CwM4alKVETxTnXQpcKHH1x5hZIAKTni/Q98JHs+teewNhUwpaWACwjuEhmF3EYSTgTXeUoeI9hAg==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pf-plots@1.4.4':
@@ -1179,8 +1184,8 @@ packages:
       '@milaboratories/pl-model-common': 1.39.0
       '@platforma-sdk/model': 1.73.3
 
-  '@milaboratories/pf-spec-driver@1.4.16':
-    resolution: {integrity: sha512-x6SQVUU3fl+1fFavCSzc1DNMB08HKoo0PT5dpXJWAi6oEw77yueoe1StZJVY0Kgj1BpVhlmuuC87PJu8s4eFRw==}
+  '@milaboratories/pf-spec-driver@1.4.18':
+    resolution: {integrity: sha512-lXaoSyGCWUlrYZaoyRIWWT0Hpx9DWODXI7VdraNjYnCofJpYKMdAZW3sfCE9kdVup8ic29vywNPLeTjrVQ24sg==}
 
   '@milaboratories/pframes-rs-node@1.1.52':
     resolution: {integrity: sha512-Uu4KsQx0GiKvFASI+Cm0nMCMieUVo35mpz4j8mYUYImr7S+bVDDcHweCWrkLkSeImnOQnYHVo9RycViG6QwUQw==}
@@ -1199,56 +1204,59 @@ packages:
       '@milaboratories/pl-model-common': 1.46.2
       '@milaboratories/pl-model-middle-layer': 1.30.7
 
-  '@milaboratories/pl-client@3.12.0':
-    resolution: {integrity: sha512-uca6tbW7hy7H/Sf010/9HNQMFKwf6bJ/JONyNgvQB+hGdJZb//vjw0xoBQDun0wSAkPm+9H2I+e0q6RUfcNZng==}
+  '@milaboratories/pl-client@3.13.2':
+    resolution: {integrity: sha512-5sx6ehEPfo7q4ojyXgPgQIzn4iPZs7YPvEPctRkwQ6cuK5KzLO059FjzUjsJDh5Si7QbUL/yi5qxCf1h1q4G6g==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-config@1.8.2':
-    resolution: {integrity: sha512-FG9rlAKDf1rwlg+3G9OG2bCKISNp6ajM27W7ODDSsWE4MSCVxhYB172UusbohY2RDmaD9GI5pDKO5O9uoHQCCA==}
+  '@milaboratories/pl-config@1.8.3':
+    resolution: {integrity: sha512-JPIWG/9q7SL9QSYUhHwF9MCfGbpJyo2KxaO9IE2gEvy+oiGw1oBJvNdthC9V/uW2jHp/Qov9+x7LveHzN+bfeA==}
 
-  '@milaboratories/pl-deployments@3.0.8':
-    resolution: {integrity: sha512-7WvA761yI7eLCdJE19uNa/a6fLxytVrKJ/utBJ6GelZQFuA/LT12VkG6r0uAFtU8afY9Sr89078oLzZSZJR/oA==}
+  '@milaboratories/pl-deployments@3.0.10':
+    resolution: {integrity: sha512-AEFI5gRH1quEUZPqV4wkYabVevpTRGMJXPILsYGh/In9eSw56aHIl8pHoZP5h8v3J5v//KNU7aP8sYANh8S7rA==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-drivers@1.16.3':
-    resolution: {integrity: sha512-/HObfG0uuFDYUd8G3qxlhrvhvTo8T5MH42+Vpr8snN+YnSHGyMXo6rw6oKRNO+h/GF+kbI5DTr9kNsQVEwyFng==}
+  '@milaboratories/pl-drivers@1.16.7':
+    resolution: {integrity: sha512-tEPv4pWekRa5W9zCX0jK6G5lxtXq5f3FVupszxGgkfeQ9op1p3qI8WA4nin52yskKmwPht0R69K97S6tOc2aSg==}
     engines: {node: '>=22'}
 
   '@milaboratories/pl-error-like@1.12.10':
     resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
 
-  '@milaboratories/pl-errors@1.4.24':
-    resolution: {integrity: sha512-pV0oF0zO6bwAo/llQlu4Q00uI0guPQ9Wn+coK3pwLrateKidVRH/2XhwUgTwgS8vDECBNCgtYR6E/Im+nl+FMw==}
+  '@milaboratories/pl-errors@1.4.28':
+    resolution: {integrity: sha512-wK/mbJSvGv1aCBCXR9YWXICjWBbWAzyAIAQgGtg3PAIJyONdSOCmV8VFUTMjatYEL/38k/0rUePP8MeYwSVm/g==}
 
-  '@milaboratories/pl-healthcheck@1.0.1':
-    resolution: {integrity: sha512-eiYd/TFm18SW4EY8vkI3c+fcPnjUu3Hd1GnPLWCN8U+dNmp/tnrzfeCgaY4xO/s0vkHNX9E7IrsQiMg2Ioz4rw==}
+  '@milaboratories/pl-healthcheck@1.0.2':
+    resolution: {integrity: sha512-IBXQOSgJj7T/dw26AXBsR1ZaOpoqxZtSFZVPE2TonT0VaLKH4XqMFa3C+fKV1aECqbI45dBRQl/X70CUdGPWgQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/pl-http@1.2.4':
     resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
-  '@milaboratories/pl-middle-layer@1.64.41':
-    resolution: {integrity: sha512-6xXwmTaaImd6HQ2PZgUWGf1gXsfgEPz3zWQsmaUaPMyMusjPVynPCX2hnThqrPVf54mEMlvc3HTGaC+dofDF0g==}
+  '@milaboratories/pl-middle-layer@1.65.6':
+    resolution: {integrity: sha512-0NSFtmG3lIXAG7N4xoSjzn7meWb7qXCUEntDtwiywll6tcAl3lR5O5iBvYqCFiGoL7KrbHXBKrMkn8p7vatEbA==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/pl-model-backend@1.4.9':
-    resolution: {integrity: sha512-84+Pv2RhonE/ZwR5bXipOGK4cC5V3C4vmhzIgc8TWpgLxUNsjCjoodSo3bzPcpA+URShTf4+3h4C28O/wO/MCw==}
+  '@milaboratories/pl-model-backend@1.4.13':
+    resolution: {integrity: sha512-HGEVDZXh/XUU5sDuBB46pMc1+46elzvrPuKCaowhqpzBPzA4j/DNxuJucJRv/h/oE0Ue3kEQf+6x0506kGDrow==}
 
   '@milaboratories/pl-model-common@1.46.2':
     resolution: {integrity: sha512-VEeauisApYScvCS8lnK3zpFJ520xuTAodKJmjR8ulHcMrWMyWMfHEdGb7j5OMD0mM/OwTgmQrrJ5eB7Xd+xoOQ==}
 
+  '@milaboratories/pl-model-common@1.46.4':
+    resolution: {integrity: sha512-QArgLyQkf8kHSQquxStyk5Xfnau8S4M2vKEbUVQRRoZCzLU1lcDVXRwGgAzRH5NizeqYNrB/wt0/tShajH+6eA==}
+
+  '@milaboratories/pl-model-middle-layer@1.30.11':
+    resolution: {integrity: sha512-yFThwVqOTb2gJw/tp4PkZcsKI7yRRJCX3QuA6fIc2+tNxCqyEQmdpLmaIY/nhaziIp9ByBT9MrzWNIQd1T9aww==}
+
   '@milaboratories/pl-model-middle-layer@1.30.7':
     resolution: {integrity: sha512-rs9x3Ron4ujR/UOdEgB8WUB1SvZ8ZAScT1Av/e4or+iiQ/CzhmK9nqtYamHVwKV+JgwIFbXQwxGvIHDVz955dQ==}
 
-  '@milaboratories/pl-model-middle-layer@1.30.9':
-    resolution: {integrity: sha512-fnrCjWPR0HeytWC3rnHkY3bpNk3UOuED+lwmauhYBKRaF46cV1df46clJSkGNZHS9g439SYwclW4no2X/ALaFQ==}
-
-  '@milaboratories/pl-tree@1.12.14':
-    resolution: {integrity: sha512-G6uUG+3b4rH0eEQP6B31unFJtxsutETJckvapqXd9u+Uo906mK4w5u6DnXcNWfhWhKx3/hp8v89CsYSDO3b7Qw==}
+  '@milaboratories/pl-tree@1.12.18':
+    resolution: {integrity: sha512-2vx0JNFDQklz23JMK8s+34LrhFqY0zDDLTLDCOdWgrlNKbd6mr956fKxmvIBML4++Ngs8Izs45B0PNGwhkEBrw==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/ptabler-expression-js@1.2.31':
-    resolution: {integrity: sha512-VB3fxuVqc0Beb+3/ge9uZ39uU8YqAhck9pTIxTpNZ5hOfMtPGJEI98YxoJQ8BuYhyyx5SM5qMU04NNs/vdk46A==}
+  '@milaboratories/ptabler-expression-js@1.2.33':
+    resolution: {integrity: sha512-ThB7tc0nPACE7b8cSoA0+zRVZfZHOCAcFioFDi207G5prgrIc/z2zbInjD0PRnWFHO7xOsfbWCkNRDqCmut6zQ==}
 
   '@milaboratories/resolve-helper@1.1.3':
     resolution: {integrity: sha512-38/dW/XRZQREOxAOOKtO0lzEWPCP/DH0qhB3q1kYcGoN++5V92/zbVwbYrMDeDcjTyo+D62iIep+sKXeWHa7Uw==}
@@ -1271,12 +1279,12 @@ packages:
   '@milaboratories/ts-configs@1.3.0':
     resolution: {integrity: sha512-6rZaMOJotG+v6eXoupHgPqxArpNBNl0f7sd5K+kUo1PUhPTe632eLJtEeBbFtwDGNYqL9QUacd4pT5t6oDOf0A==}
 
-  '@milaboratories/ts-helpers@1.8.3':
-    resolution: {integrity: sha512-HK3AmNZl2fOzMHot2+ihKsOC+fluwhl5261VTn1zGS3LRpmC9bCk/po8SzsVmg79ccI5nESFTdz+BRaLsXncmQ==}
+  '@milaboratories/ts-helpers@1.8.4':
+    resolution: {integrity: sha512-YdOyANkJjFiEZgS3bfbludDo9PWOQZQ8AhGw/rpO5/7bgQ9RIVOOTAtP5/UppANoeUiYhCgJt/xvIZgnQ/PZ0w==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/uikit@2.15.11':
-    resolution: {integrity: sha512-oBQiPXpHEwg1dLptfCQNtpRrJ3stunjrTWiP5U90rAXl4c6Z/Ks7YU/fVvoqdBsoSBQ6nEcAG0Sk4sV8DVRlJQ==}
+  '@milaboratories/uikit@2.15.13':
+    resolution: {integrity: sha512-IdPV9xuwULSx0zXc006dzfOatJBHJ39TmsBnkdsQ235Jz+c++Klpp8tBvDjeXO10nv0xQiIRTXvDCeXebrRTOg==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -1612,14 +1620,14 @@ packages:
   '@platforma-open/milaboratories.runenv-python-3@1.10.3':
     resolution: {integrity: sha512-ArdWMYMk4hkc8likdmI6h2sv0Eh3RV4mYkXeLn/WZFU/WpLYxv+eKKNeeTcQjov0AP8VkqN1cwhMCfqcv+UudA==}
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.15':
-    resolution: {integrity: sha512-zvPuRZgQyxjED+txJVgWHUOPeRp4TG1jOrJOtuw9WnwxFiHNjQHIB+Xe1j8f6skgMqZgRSQvEbhRvqbWjGmhKQ==}
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.17':
+    resolution: {integrity: sha512-Qf4QpFY8bWVtEeQphWGZ67dUaXYVWSFm/AL1ErzdOYhilnDSon2Cya6K2Fkj0TxEGBLMBxOudF/kmTw728/Pag==}
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.3':
-    resolution: {integrity: sha512-4cikdkdJ5WYc0Nw3IoZxzlFNKvG1qCAqSjypq5b18pIK6LBDayzhFcuw5TDd8O3bAFhoHP+3cVTmoO9XUTYMRg==}
+  '@platforma-open/milaboratories.software-ptabler@2.1.4':
+    resolution: {integrity: sha512-hLGDR7xVKoKj+4IM+fiWmJjFvYCZ2JmDQ7/Z99nq1zglAJJ1dqqVrtZ2TJ67HNyORpe1CrkRXvP9kNc4JxBUgA==}
 
-  '@platforma-open/milaboratories.software-ptexter@1.2.2':
-    resolution: {integrity: sha512-I08YpKQ4+esLrfpVra5UJ+bznI9Zzba6OW0rKK407a1EUmanvYMVrCbM9gqnm6CHbv2vQxNGSaO8p1LoBh+9gA==}
+  '@platforma-open/milaboratories.software-ptexter@1.2.3':
+    resolution: {integrity: sha512-5wwzvPko/tjkm6EnirsnjB+MO5mF//tgJplI+jPh3bcSHpEdHF+B9xg+S1owAnekqbimMrFZWqHSVY9ZmIHOjw==}
 
   '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10':
     resolution: {integrity: sha512-16BGRLIrsVW+YIaXwWLX6Nbm80PS5mQJEclHhjNbRrRTLHPaKI4RygZfBC0lLNzvHBiTXU4Qkh1+WmdovkshDg==}
@@ -1642,37 +1650,33 @@ packages:
   '@platforma-open/soedinglab.software-mmseqs2@1.18.0':
     resolution: {integrity: sha512-qZw1HPzF1TCjQXmckGUHK5o7/ErVomiY+Ink1Jj44GS8j+lG+LPoJvqVjtFSxUm9fCdzfQg6rCC78tbS/JiPpw==}
 
-  '@platforma-sdk/block-tools@2.11.6':
-    resolution: {integrity: sha512-CyekNfqEildNeTrkjAeaWC7ah+skGMb3d/crSZSgCWACPIVQwg2oRZiJliwmJU/ylcTONPDAef7DYOtmfXsgtw==}
+  '@platforma-sdk/block-tools@2.12.2':
+    resolution: {integrity: sha512-IDC+kW0SGNn+d1CvEIX48DWcPpqqLYE/TZgSJ1MYEuzTCjRNBpYWEhu3OjglxsIjGfEQnAkfkpnzJIXrBU9zyQ==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.2.0':
     resolution: {integrity: sha512-p9lBxhFXM9WoRsrJO7dfkiXSK+1m63yIn1sKhBO71eMbhrLMyVYHEOeNf3w5OCdbRF5QsNhXzWuiTmFK3zHFsA==}
     hasBin: true
 
-  '@platforma-sdk/model@1.79.20':
-    resolution: {integrity: sha512-0ULETzwgo4E5rIddn/PoCAY5gSv9luDYAaSp66b8u3u1XTh43k7fgOpobu/rrfHJMiY9IGfzALDlo6jtvMLUyQ==}
+  '@platforma-sdk/model@1.79.27':
+    resolution: {integrity: sha512-Z5WYpClTZoBtvfGsiDPNlRCxPKtUF04TV3MmL1Kfb6xAb04B5NdiqWMnqw+v78Kue/y9FKTmxrCcX9lwZgYFlw==}
 
-  '@platforma-sdk/package-builder-lib@1.1.0':
-    resolution: {integrity: sha512-h/Hx4Fg+kGnX2sVPWJa48JHbSEofTnaOescTKBP1Py5wl3A68BjqKaI6yybLWSR5Ojp3tHNNlvFSAnoF2QYMMg==}
+  '@platforma-sdk/package-builder-lib@1.2.0':
+    resolution: {integrity: sha512-AtSzaZ39BGlqcyYtpGREDz+YlGCDdSTQJNV/+NkTyUtoq1ECRO+iMqAX1DSSza1WqylnURX8vKVI2owS/cxntA==}
 
-  '@platforma-sdk/package-builder@3.14.0':
-    resolution: {integrity: sha512-7bRducsc9NLc1zo0GRfz3RHSTejxFfmFvr21EH8NBndGaCj5KvHt2+0jmQsSI1Sl7ZCaj+zQKWWukRlsi+b/uA==}
-    hasBin: true
-
-  '@platforma-sdk/tengo-builder@4.0.11':
-    resolution: {integrity: sha512-c0LuiR7vtclto853Q1O+j8g109ooIZKtEl5tqRHG6dN/kk6S+J7DZHCpAjFuZ9pt3x6jF95sNaJEtP8uFs1uXw==}
+  '@platforma-sdk/tengo-builder@4.0.15':
+    resolution: {integrity: sha512-qBWtAD1f1ZFFfkN7mvYKaI2qKbvQ9wHVh5edGTaKMFU5GFEu5IA3RP4SJw4ht69WjXAEu51VOvvPFwRX1P4H3g==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@platforma-sdk/test@1.79.23':
-    resolution: {integrity: sha512-vb5K4Rtjy5ogom3fBYpOxvKL+Nb50iURUdd1vjzN3pcQGx47omBnDr9YvNvUsRC3INhZibLzy44dUKD2la/IMw==}
+  '@platforma-sdk/test@1.79.31':
+    resolution: {integrity: sha512-AZpmbl8CxN8Xg96C8bTO8WR9VLrK/umTzwD1VVp5ieYaerGg9at8thub0jjJ+YYkoIH7TWVU1nn85FvcqpSoaw==}
 
-  '@platforma-sdk/ui-vue@1.79.20':
-    resolution: {integrity: sha512-VwBG8MKV1M2KMR2PgW+o6uxJJRCFGihaRsnkzLL8HGKM/Vr9k3FY/V929B1XAhU5y9wb1g7fKNJvy9JNEq5GiQ==}
+  '@platforma-sdk/ui-vue@1.79.27':
+    resolution: {integrity: sha512-L88b8A42n4GRGqMHY4n5o+ROwxPBFSgnwr7axjb1k/zfvKRsawz5urxQ8IEPGQW/41UhxNImIiDmdOD17vHtJQ==}
 
-  '@platforma-sdk/workflow-tengo@6.6.5':
-    resolution: {integrity: sha512-BIY0DongPruQ7e2EMYy2b0UtO5ziGcLvr2RWgJ8ki17VKNzW3esm/RBszGHMrTYmXM0Yw7mCSasor4vH560g7A==}
+  '@platforma-sdk/workflow-tengo@6.7.0':
+    resolution: {integrity: sha512-hotcGbt42gbMRpNp4PEtE8TBLAQXn+V2LM1SCyY5cnc+tWXxUwhgQnfNsg/xOvbu2qxUZhVrGisvb7Ruj+L2IA==}
 
   '@protobuf-ts/grpc-transport@2.11.1':
     resolution: {integrity: sha512-l6wrcFffY+tuNnuyrNCkRM8hDIsAZVLA8Mn7PKdVyYxITosYh60qW663p9kL6TWXYuDCL3oxH8ih3vLKTDyhtg==}
@@ -5328,9 +5332,6 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
-  obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
-
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
@@ -6498,6 +6499,50 @@ snapshots:
       '@aws-sdk/types': 3.840.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
+
+  '@aws-sdk/client-ecr-public@3.859.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.858.0
+      '@aws-sdk/credential-provider-node': 3.859.0
+      '@aws-sdk/middleware-host-header': 3.840.0
+      '@aws-sdk/middleware-logger': 3.840.0
+      '@aws-sdk/middleware-recursion-detection': 3.840.0
+      '@aws-sdk/middleware-user-agent': 3.858.0
+      '@aws-sdk/region-config-resolver': 3.840.0
+      '@aws-sdk/types': 3.840.0
+      '@aws-sdk/util-endpoints': 3.848.0
+      '@aws-sdk/util-user-agent-browser': 3.840.0
+      '@aws-sdk/util-user-agent-node': 3.858.0
+      '@smithy/config-resolver': 4.1.5
+      '@smithy/core': 3.8.0
+      '@smithy/fetch-http-handler': 5.1.1
+      '@smithy/hash-node': 4.0.4
+      '@smithy/invalid-dependency': 4.0.4
+      '@smithy/middleware-content-length': 4.0.4
+      '@smithy/middleware-endpoint': 4.1.18
+      '@smithy/middleware-retry': 4.1.19
+      '@smithy/middleware-serde': 4.0.9
+      '@smithy/middleware-stack': 4.0.5
+      '@smithy/node-config-provider': 4.1.4
+      '@smithy/node-http-handler': 4.1.1
+      '@smithy/protocol-http': 5.1.3
+      '@smithy/smithy-client': 4.4.10
+      '@smithy/types': 4.3.2
+      '@smithy/url-parser': 4.0.5
+      '@smithy/util-base64': 4.0.0
+      '@smithy/util-body-length-browser': 4.0.0
+      '@smithy/util-body-length-node': 4.0.0
+      '@smithy/util-defaults-mode-browser': 4.0.26
+      '@smithy/util-defaults-mode-node': 4.0.26
+      '@smithy/util-endpoints': 3.0.6
+      '@smithy/util-middleware': 4.0.5
+      '@smithy/util-retry': 4.0.7
+      '@smithy/util-utf8': 4.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
 
   '@aws-sdk/client-s3@3.859.0':
     dependencies:
@@ -7710,21 +7755,21 @@ snapshots:
 
   '@milaboratories/biowasm-tools@2.0.3': {}
 
-  '@milaboratories/computable@2.9.5':
+  '@milaboratories/computable@2.9.6':
     dependencies:
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers': 1.8.4
       '@types/node': 24.5.2
       utility-types: 3.11.0
 
-  '@milaboratories/graph-maker@1.4.6(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.20)(@platforma-sdk/ui-vue@1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
+  '@milaboratories/graph-maker@1.4.6(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)(@platforma-sdk/ui-vue@1.79.27(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
     dependencies:
       '@ag-grid-community/core': 32.3.5
       '@milaboratories/helpers': 1.14.2
       '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.20)
-      '@platforma-sdk/model': 1.79.20
-      '@platforma-sdk/ui-vue': 1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)
+      '@platforma-sdk/model': 1.79.27
+      '@platforma-sdk/ui-vue': 1.79.27(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       '@types/d3-hierarchy': 3.1.7
       '@types/d3-scale': 4.0.9
       '@vueuse/core': 13.4.0(vue@3.5.25(typescript@5.9.3))
@@ -7742,6 +7787,8 @@ snapshots:
       - typescript
 
   '@milaboratories/helpers@1.14.2': {}
+
+  '@milaboratories/helpers@1.14.3': {}
 
   '@milaboratories/miplots4@1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
     dependencies:
@@ -7781,13 +7828,13 @@ snapshots:
       - d3-scale-chromatic
       - supports-color
 
-  '@milaboratories/multi-sequence-alignment@1.47.16(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.20)(@platforma-sdk/ui-vue@1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
+  '@milaboratories/multi-sequence-alignment@1.47.16(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)(@platforma-sdk/ui-vue@1.79.27(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3))(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(typescript@5.9.3)':
     dependencies:
       '@milaboratories/biowasm-tools': 2.0.3
       '@milaboratories/miplots4': 1.2.2(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)
-      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.20)
-      '@platforma-sdk/model': 1.79.20
-      '@platforma-sdk/ui-vue': 1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
+      '@milaboratories/pf-plots': 1.4.4(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)
+      '@platforma-sdk/model': 1.79.27
+      '@platforma-sdk/ui-vue': 1.79.27(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)
       vue: 3.5.25(typescript@5.9.3)
     transitivePeerDependencies:
       - '@milaboratories/pl-model-common'
@@ -7797,14 +7844,14 @@ snapshots:
       - supports-color
       - typescript
 
-  '@milaboratories/pf-driver@1.7.14(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-driver@1.7.16(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': 1.14.3
       '@milaboratories/pframes-rs-node': 1.1.52
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.9)
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-middle-layer': 1.30.11
+      '@milaboratories/ts-helpers': 1.8.4
       es-toolkit: 1.39.10
       lru-cache: 11.2.2
     transitivePeerDependencies:
@@ -7812,20 +7859,20 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pf-plots@1.4.4(@milaboratories/pl-model-common@1.46.2)(@platforma-sdk/model@1.79.20)':
+  '@milaboratories/pf-plots@1.4.4(@milaboratories/pl-model-common@1.46.4)(@platforma-sdk/model@1.79.27)':
     dependencies:
       '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.46.2
-      '@platforma-sdk/model': 1.79.20
+      '@milaboratories/pl-model-common': 1.46.4
+      '@platforma-sdk/model': 1.79.27
       canonicalize: 2.1.0
       lodash: 4.17.21
 
-  '@milaboratories/pf-spec-driver@1.4.16(@bytecodealliance/preview2-shim@0.17.8)':
+  '@milaboratories/pf-spec-driver@1.4.18(@bytecodealliance/preview2-shim@0.17.8)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.9)
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-middle-layer': 1.30.11
       '@noble/hashes': 2.0.1
     transitivePeerDependencies:
       - '@bytecodealliance/preview2-shim'
@@ -7852,19 +7899,19 @@ snapshots:
 
   '@milaboratories/pframes-rs-wasip2@1.1.52': {}
 
-  '@milaboratories/pframes-rs-wasm@1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.9)':
+  '@milaboratories/pframes-rs-wasm@1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.8
       '@milaboratories/pframes-rs-wasip2': 1.1.52
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-middle-layer': 1.30.11
 
-  '@milaboratories/pl-client@3.12.0':
+  '@milaboratories/pl-client@3.13.2':
     dependencies:
       '@grpc/grpc-js': 1.13.4
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/ts-helpers': 1.8.4
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -7877,19 +7924,19 @@ snapshots:
       utility-types: 3.11.0
       yaml: 2.8.1
 
-  '@milaboratories/pl-config@1.8.2':
+  '@milaboratories/pl-config@1.8.3':
     dependencies:
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers': 1.8.4
       upath: 2.0.1
       yaml: 2.8.1
 
-  '@milaboratories/pl-deployments@3.0.8':
+  '@milaboratories/pl-deployments@3.0.10':
     dependencies:
-      '@milaboratories/pl-config': 1.8.2
-      '@milaboratories/pl-healthcheck': 1.0.1
+      '@milaboratories/pl-config': 1.8.3
+      '@milaboratories/pl-healthcheck': 1.0.2
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/ts-helpers': 1.8.4
       decompress: 4.2.1
       ssh2: 1.16.0
       tar: 7.4.3
@@ -7898,15 +7945,15 @@ snapshots:
       yaml: 2.8.1
       zod: 3.25.76
 
-  '@milaboratories/pl-drivers@1.16.3':
+  '@milaboratories/pl-drivers@1.16.7':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@milaboratories/computable': 2.9.5
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-tree': 1.12.14
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/computable': 2.9.6
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pl-client': 3.13.2
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-tree': 1.12.18
+      '@milaboratories/ts-helpers': 1.8.4
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/plugin': 2.11.1
       '@protobuf-ts/runtime': 2.11.1
@@ -7926,16 +7973,16 @@ snapshots:
       json-stringify-safe: 5.0.1
       zod: 3.25.76
 
-  '@milaboratories/pl-errors@1.4.24':
+  '@milaboratories/pl-errors@1.4.28':
     dependencies:
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/pl-client': 3.13.2
+      '@milaboratories/ts-helpers': 1.8.4
       zod: 3.25.76
 
-  '@milaboratories/pl-healthcheck@1.0.1':
+  '@milaboratories/pl-healthcheck@1.0.2':
     dependencies:
       '@grpc/grpc-js': 1.13.4
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers': 1.8.4
       '@protobuf-ts/grpc-transport': 2.11.1(@grpc/grpc-js@1.13.4)
       '@protobuf-ts/runtime': 2.11.1
       '@protobuf-ts/runtime-rpc': 2.11.1
@@ -7944,28 +7991,28 @@ snapshots:
     dependencies:
       undici: 7.16.0
 
-  '@milaboratories/pl-middle-layer@1.64.41(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
+  '@milaboratories/pl-middle-layer@1.65.6(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)':
     dependencies:
-      '@milaboratories/computable': 2.9.5
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pf-driver': 1.7.14(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pf-spec-driver': 1.4.16(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/computable': 2.9.6
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pf-driver': 1.7.16(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pf-spec-driver': 1.4.18(@bytecodealliance/preview2-shim@0.17.8)
       '@milaboratories/pframes-rs-node': 1.1.52
-      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.2)(@milaboratories/pl-model-middle-layer@1.30.9)
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/pl-deployments': 3.0.8
-      '@milaboratories/pl-drivers': 1.16.3
-      '@milaboratories/pl-errors': 1.4.24
+      '@milaboratories/pframes-rs-wasm': 1.1.52(@bytecodealliance/preview2-shim@0.17.8)(@milaboratories/pl-model-common@1.46.4)(@milaboratories/pl-model-middle-layer@1.30.11)
+      '@milaboratories/pl-client': 3.13.2
+      '@milaboratories/pl-deployments': 3.0.10
+      '@milaboratories/pl-drivers': 1.16.7
+      '@milaboratories/pl-errors': 1.4.28
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.9
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
-      '@milaboratories/pl-tree': 1.12.14
+      '@milaboratories/pl-model-backend': 1.4.13
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-middle-layer': 1.30.11
+      '@milaboratories/pl-tree': 1.12.18
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.3
-      '@platforma-sdk/block-tools': 2.11.6(@types/node@24.5.2)
-      '@platforma-sdk/model': 1.79.20
-      '@platforma-sdk/workflow-tengo': 6.6.5
+      '@milaboratories/ts-helpers': 1.8.4
+      '@platforma-sdk/block-tools': 2.12.2(@types/node@24.5.2)
+      '@platforma-sdk/model': 1.79.27
+      '@platforma-sdk/workflow-tengo': 6.7.0
       canonicalize: 2.1.0
       denque: 2.1.0
       es-toolkit: 1.39.10
@@ -7983,9 +8030,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@milaboratories/pl-model-backend@1.4.9':
+  '@milaboratories/pl-model-backend@1.4.13':
     dependencies:
-      '@milaboratories/pl-client': 3.12.0
+      '@milaboratories/pl-client': 3.13.2
       canonicalize: 2.1.0
       zod: 3.25.76
 
@@ -7996,6 +8043,21 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.25.76
 
+  '@milaboratories/pl-model-common@1.46.4':
+    dependencies:
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pl-error-like': 1.12.10
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-middle-layer@1.30.11':
+    dependencies:
+      '@milaboratories/helpers': 1.14.3
+      '@milaboratories/pl-model-common': 1.46.4
+      es-toolkit: 1.39.10
+      utility-types: 3.11.0
+      zod: 3.25.76
+
   '@milaboratories/pl-model-middle-layer@1.30.7':
     dependencies:
       '@milaboratories/helpers': 1.14.2
@@ -8004,27 +8066,19 @@ snapshots:
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/pl-model-middle-layer@1.30.9':
+  '@milaboratories/pl-tree@1.12.18':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@milaboratories/pl-model-common': 1.46.2
-      es-toolkit: 1.39.10
-      utility-types: 3.11.0
-      zod: 3.25.76
-
-  '@milaboratories/pl-tree@1.12.14':
-    dependencies:
-      '@milaboratories/computable': 2.9.5
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/pl-errors': 1.4.24
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/computable': 2.9.6
+      '@milaboratories/pl-client': 3.13.2
+      '@milaboratories/pl-errors': 1.4.28
+      '@milaboratories/ts-helpers': 1.8.4
       denque: 2.1.0
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@milaboratories/ptabler-expression-js@1.2.31':
+  '@milaboratories/ptabler-expression-js@1.2.33':
     dependencies:
-      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.15
+      '@platforma-open/milaboratories.software-ptabler.schema': 1.15.17
 
   '@milaboratories/resolve-helper@1.1.3': {}
 
@@ -8159,16 +8213,16 @@ snapshots:
 
   '@milaboratories/ts-configs@1.3.0': {}
 
-  '@milaboratories/ts-helpers@1.8.3':
+  '@milaboratories/ts-helpers@1.8.4':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': 1.14.3
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/uikit@2.15.11(typescript@5.9.3)':
+  '@milaboratories/uikit@2.15.13(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
-      '@platforma-sdk/model': 1.79.20
+      '@milaboratories/helpers': 1.14.3
+      '@platforma-sdk/model': 1.79.27
       '@types/d3-array': 3.2.1
       '@types/d3-axis': 3.0.6
       '@types/d3-scale': 4.0.9
@@ -8475,13 +8529,13 @@ snapshots:
       '@platforma-open/milaboratories.runenv-python-3.12.10-scientific-slim': 1.1.0
       '@platforma-open/milaboratories.runenv-python-3.12.10-torch-cuda': 0.1.0
 
-  '@platforma-open/milaboratories.software-ptabler.schema@1.15.15':
+  '@platforma-open/milaboratories.software-ptabler.schema@1.15.17':
     dependencies:
-      '@milaboratories/pl-model-common': 1.46.2
+      '@milaboratories/pl-model-common': 1.46.4
 
-  '@platforma-open/milaboratories.software-ptabler@2.1.3': {}
+  '@platforma-open/milaboratories.software-ptabler@2.1.4': {}
 
-  '@platforma-open/milaboratories.software-ptexter@1.2.2': {}
+  '@platforma-open/milaboratories.software-ptexter@1.2.3': {}
 
   '@platforma-open/milaboratories.software-small-binaries.hello-world-py@1.0.10': {}
 
@@ -8503,17 +8557,19 @@ snapshots:
 
   '@platforma-open/soedinglab.software-mmseqs2@1.18.0': {}
 
-  '@platforma-sdk/block-tools@2.11.6(@types/node@24.5.2)':
+  '@platforma-sdk/block-tools@2.12.2(@types/node@24.5.2)':
     dependencies:
+      '@aws-sdk/client-ecr-public': 3.859.0
       '@aws-sdk/client-s3': 3.859.0
       '@inquirer/prompts': 7.10.1(@types/node@24.5.2)
       '@milaboratories/pl-http': 1.2.4
-      '@milaboratories/pl-model-backend': 1.4.9
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
+      '@milaboratories/pl-model-backend': 1.4.13
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-middle-layer': 1.30.11
       '@milaboratories/resolve-helper': 1.1.3
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers': 1.8.4
       '@platforma-sdk/blocks-deps-updater': 2.2.0
+      '@platforma-sdk/package-builder-lib': 1.2.0
       canonicalize: 2.1.0
       commander: 15.0.0
       lru-cache: 11.2.2
@@ -8530,20 +8586,20 @@ snapshots:
     dependencies:
       yaml: 2.8.1
 
-  '@platforma-sdk/model@1.79.20':
+  '@platforma-sdk/model@1.79.27':
     dependencies:
-      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/helpers': 1.14.3
       '@milaboratories/pl-error-like': 1.12.10
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/pl-model-middle-layer': 1.30.9
-      '@milaboratories/ptabler-expression-js': 1.2.31
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/pl-model-middle-layer': 1.30.11
+      '@milaboratories/ptabler-expression-js': 1.2.33
       canonicalize: 2.1.0
       es-toolkit: 1.39.10
       fast-json-patch: 3.1.1
       utility-types: 3.11.0
       zod: 3.25.76
 
-  '@platforma-sdk/package-builder-lib@1.1.0':
+  '@platforma-sdk/package-builder-lib@1.2.0':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
       '@aws-sdk/lib-storage': 3.859.0(@aws-sdk/client-s3@3.859.0)
@@ -8556,30 +8612,22 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@platforma-sdk/package-builder@3.14.0':
+  '@platforma-sdk/tengo-builder@4.0.15':
     dependencies:
-      '@platforma-sdk/package-builder-lib': 1.1.0
-      commander: 15.0.0
-      winston: 3.17.0
-    transitivePeerDependencies:
-      - aws-crt
-
-  '@platforma-sdk/tengo-builder@4.0.11':
-    dependencies:
-      '@milaboratories/pl-model-backend': 1.4.9
+      '@milaboratories/pl-model-backend': 1.4.13
       '@milaboratories/resolve-helper': 1.1.3
       '@milaboratories/tengo-tester': 1.6.4
-      '@milaboratories/ts-helpers': 1.8.3
+      '@milaboratories/ts-helpers': 1.8.4
       commander: 15.0.0
       winston: 3.17.0
 
-  '@platforma-sdk/test@1.79.23(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.3.5(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1))':
+  '@platforma-sdk/test@1.79.31(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@6.3.5(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1))':
     dependencies:
-      '@milaboratories/computable': 2.9.5
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/pl-middle-layer': 1.64.41(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
-      '@milaboratories/pl-tree': 1.12.14
-      '@platforma-sdk/model': 1.79.20
+      '@milaboratories/computable': 2.9.6
+      '@milaboratories/pl-client': 3.13.2
+      '@milaboratories/pl-middle-layer': 1.65.6(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
+      '@milaboratories/pl-tree': 1.12.18
+      '@platforma-sdk/model': 1.79.27
       '@vitest/coverage-istanbul': 4.1.5(vitest@4.0.8(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1))
       vitest: 4.1.5(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.5)(vite@6.3.5(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1))
     transitivePeerDependencies:
@@ -8600,13 +8648,13 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/test@1.79.23(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))':
+  '@platforma-sdk/test@1.79.31(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))':
     dependencies:
-      '@milaboratories/computable': 2.9.5
-      '@milaboratories/pl-client': 3.12.0
-      '@milaboratories/pl-middle-layer': 1.64.41(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
-      '@milaboratories/pl-tree': 1.12.14
-      '@platforma-sdk/model': 1.79.20
+      '@milaboratories/computable': 2.9.6
+      '@milaboratories/pl-client': 3.13.2
+      '@milaboratories/pl-middle-layer': 1.65.6(@bytecodealliance/preview2-shim@0.17.8)(@types/node@24.5.2)
+      '@milaboratories/pl-tree': 1.12.18
+      '@platforma-sdk/model': 1.79.27
       '@vitest/coverage-istanbul': 4.1.5(vitest@4.1.5)
       vitest: 4.1.5(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.5)(vite@8.0.10(@types/node@24.5.2)(yaml@2.8.1))
     transitivePeerDependencies:
@@ -8627,12 +8675,12 @@ snapshots:
       - supports-color
       - vite
 
-  '@platforma-sdk/ui-vue@1.79.20(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
+  '@platforma-sdk/ui-vue@1.79.27(@bytecodealliance/preview2-shim@0.17.8)(typescript@5.9.3)':
     dependencies:
-      '@milaboratories/pf-spec-driver': 1.4.16(@bytecodealliance/preview2-shim@0.17.8)
-      '@milaboratories/pl-model-common': 1.46.2
-      '@milaboratories/uikit': 2.15.11(typescript@5.9.3)
-      '@platforma-sdk/model': 1.79.20
+      '@milaboratories/pf-spec-driver': 1.4.18(@bytecodealliance/preview2-shim@0.17.8)
+      '@milaboratories/pl-model-common': 1.46.4
+      '@milaboratories/uikit': 2.15.13(typescript@5.9.3)
+      '@platforma-sdk/model': 1.79.27
       '@types/d3-format': 3.0.4
       '@types/node': 24.5.2
       '@types/semver': 7.7.0
@@ -8663,12 +8711,12 @@ snapshots:
       - typescript
       - universal-cookie
 
-  '@platforma-sdk/workflow-tengo@6.6.5':
+  '@platforma-sdk/workflow-tengo@6.7.0':
     dependencies:
       '@milaboratories/pframes-rs-wasip2': 1.1.52
       '@milaboratories/software-pframes-conv': 2.2.9
-      '@platforma-open/milaboratories.software-ptabler': 2.1.3
-      '@platforma-open/milaboratories.software-ptexter': 1.2.2
+      '@platforma-open/milaboratories.software-ptabler': 2.1.4
+      '@platforma-open/milaboratories.software-ptexter': 1.2.3
       '@platforma-open/milaboratories.software-small-binaries': 2.1.1
 
   '@protobuf-ts/grpc-transport@2.11.1(@grpc/grpc-js@1.13.4)':
@@ -11461,7 +11509,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.2
-      obug: 2.1.1
+      obug: 2.1.3
       tinyrainbow: 3.1.0
       vitest: 4.0.8(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1)
     transitivePeerDependencies:
@@ -11477,7 +11525,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.2
-      obug: 2.1.1
+      obug: 2.1.3
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@types/node@24.5.2)(@vitest/coverage-istanbul@4.1.5)(vite@6.3.5(@types/node@24.5.2)(lightningcss@1.32.0)(yaml@2.8.1))
     transitivePeerDependencies:
@@ -13031,8 +13079,6 @@ snapshots:
 
   object-assign@4.1.1: {}
 
-  obug@2.1.1: {}
-
   obug@2.1.3: {}
 
   once@1.4.0:
@@ -13950,7 +13996,7 @@ snapshots:
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
       picomatch: 4.0.4
       std-env: 4.0.0
@@ -13978,7 +14024,7 @@ snapshots:
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
       picomatch: 4.0.4
       std-env: 4.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,13 +10,13 @@ catalog:
   # SDK packages - EXACT VERSIONS (no ^ or ~)
   '@milaboratories/ts-builder': 1.6.0
   '@milaboratories/ts-configs': 1.3.0
-  '@platforma-sdk/workflow-tengo': 6.6.5
-  '@platforma-sdk/model': 1.79.20
-  '@platforma-sdk/ui-vue': 1.79.20
-  '@platforma-sdk/tengo-builder': 4.0.11
-  '@platforma-sdk/package-builder': 3.14.0
-  '@platforma-sdk/block-tools': 2.11.6
-  '@platforma-sdk/test': 1.79.23
+  '@platforma-sdk/workflow-tengo': 6.7.0
+  '@platforma-sdk/model': 1.79.27
+  '@platforma-sdk/ui-vue': 1.79.27
+  '@platforma-sdk/tengo-builder': 4.0.15
+  '@platforma-sdk/package-builder': 3.14.1
+  '@platforma-sdk/block-tools': 2.12.2
+  '@platforma-sdk/test': 1.79.31
   '@milaboratories/helpers': 1.14.2
   '@milaboratories/strings': 0.1.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   '@platforma-sdk/package-builder': 3.14.1
   '@platforma-sdk/block-tools': 2.12.2
   '@platforma-sdk/test': 1.79.31
-  '@milaboratories/helpers': 1.14.2
+  '@milaboratories/helpers': 1.14.3
   '@milaboratories/strings': 0.1.2
 
   # Block-specific dependencies

--- a/software/package.json
+++ b/software/package.json
@@ -6,16 +6,15 @@
   ],
   "type": "module",
   "scripts": {
-    "build": "pl-pkg build",
-    "prepublishOnly": "pl-pkg prepublish",
-    "do-pack": "shx rm -f *.tgz && pl-pkg build && pnpm pack && shx mv platforma-open*.tgz package.tgz",
+    "build": "block-tools software build",
+    "do-pack": "shx rm -f *.tgz && block-tools software build && pnpm pack && shx mv platforma-open*.tgz package.tgz",
     "changeset": "changeset",
     "version-packages": "changeset version"
   },
   "dependencies": {},
   "devDependencies": {
     "@platforma-open/milaboratories.runenv-python-3": "catalog:",
-    "@platforma-sdk/package-builder": "catalog:"
+    "@platforma-sdk/block-tools": "catalog:"
   },
   "block-software": {
     "entrypoints": {

--- a/software/pyproject.toml
+++ b/software/pyproject.toml
@@ -1,0 +1,52 @@
+[project]
+name = "clonotype-clustering-calc-script"
+version = "0.0.0"
+requires-python = ">=3.12.0, <3.13"
+
+[dependency-groups]
+dev = [
+    "polars-lts-cpu==1.33.1",
+    "polars-ds-lts-cpu==0.10.2",
+    "pytest>=8.0.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+addopts = "-ra --strict-markers"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
+
+[tool.coverage.run]
+source = ["src"]
+branch = true
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.:",
+    "raise NotImplementedError",
+]
+
+[tool.ruff]
+exclude = [
+    ".bzr", ".direnv", ".eggs", ".git", ".git-rewrite", ".hg",
+    ".ipynb_checkpoints", ".mypy_cache", ".nox", ".pants.d",
+    ".pyenv", ".pytest_cache", ".pytype", ".ruff_cache", ".svn",
+    ".tox", ".venv", ".vscode", "__pypackages__", "_build",
+    "buck-out", "build", "dist", "node_modules", "site-packages", "venv",
+]
+line-length = 120
+indent-width = 4
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "E501", "F", "I"]
+ignore = []
+fixable = ["ALL"]
+unfixable = []
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/software/src/process_results.py
+++ b/software/src/process_results.py
@@ -6,6 +6,8 @@ import base64
 import hashlib
 import kalign
 
+from reassign_singletons import reassign_singletons
+
 # --- Computed-centroid (kalign MSA consensus) constants ---
 # Each cluster's distinct member sequences are aligned with kalign (multiple
 # sequence alignment); the centroid is the per-column majority residue over that
@@ -137,124 +139,6 @@ clusters = clusters.with_columns(
     pl.col("clusterId").str.strip_prefix("s-"),
     pl.col("clonotypeKey").str.strip_prefix("s-")
 )
-
-def reassign_singletons(clusters: pl.DataFrame, cloneTable: pl.DataFrame,
-                        min_seq_id: float) -> pl.DataFrame:
-    """Reassign singleton cluster representatives to nearby non-singleton clusters.
-
-    MMseqs2 kmer prefilter (k=5) can miss valid matches for short sequences (5-7 aa),
-    leaving them as incorrect singletons. This function checks each singleton
-    representative against all non-singleton centroids using bounded Levenshtein distance.
-
-    Returns the (possibly updated) clusters DataFrame.
-    """
-    seq_col = 'trimmed_fullSequence' if 'trimmed_fullSequence' in cloneTable.columns else (
-        'fullSequence' if 'fullSequence' in cloneTable.columns else None)
-
-    if not seq_col:
-        print("Singleton reassignment: skipped (no sequence columns available)")
-        return clusters
-
-    # Count representatives per cluster (before dedup expansion)
-    rep_sizes = clusters.group_by("clusterId").agg(pl.len().alias("rep_size"))
-    singleton_ids = rep_sizes.filter(pl.col("rep_size") == 1)["clusterId"]
-    non_singleton_centroids = rep_sizes.filter(pl.col("rep_size") > 1)
-
-    if singleton_ids.len() == 0 or non_singleton_centroids.height == 0:
-        print(f"Singleton reassignment: skipped "
-              f"({'no singletons' if singleton_ids.len() == 0 else 'no non-singleton clusters to reassign to'})")
-        return clusters
-
-    # Sequence lookup from cloneTable (keyed by clonotypeKey)
-    seq_df = (
-        cloneTable.select(["clonotypeKey", seq_col])
-        .unique("clonotypeKey", keep="first")
-    )
-
-    # Singleton members with their sequences
-    singleton_df = (
-        clusters.filter(pl.col("clusterId").is_in(singleton_ids))
-        .select(pl.col("clonotypeKey").alias("member_key"))
-        .join(
-            seq_df.select(
-                pl.col("clonotypeKey").alias("member_key"),
-                pl.col(seq_col).alias("member_seq")
-            ),
-            on="member_key", how="inner"
-        )
-    )
-
-    # Non-singleton centroids with their sequences and sizes
-    centroid_df = (
-        non_singleton_centroids
-        .select(["clusterId", "rep_size"])
-        .join(
-            seq_df.select(
-                pl.col("clonotypeKey").alias("clusterId"),
-                pl.col(seq_col).alias("centroid_seq")
-            ),
-            on="clusterId", how="inner"
-        )
-    )
-
-    n_singletons = singleton_df.height
-    n_centroids = centroid_df.height
-    print(f"Singleton reassignment: checking {n_singletons} singletons against {n_centroids} centroids...")
-
-    # Cross-join all singletons with all centroids, compute Levenshtein in Rust via polars_ds
-    cross = singleton_df.join(centroid_df, how="cross")
-    cross = cross.with_columns(
-        pds.str_leven(pl.col("member_seq"), pl.col("centroid_seq"), return_sim=False).alias("distance"),
-        pl.max_horizontal(
-            pl.col("member_seq").str.len_chars(),
-            pl.col("centroid_seq").str.len_chars()
-        ).alias("max_len")
-    )
-
-    # Filter to matches within identity threshold: distance / max_len <= (1 - min_seq_id)
-    max_dist_frac = 1.0 - min_seq_id
-    matches = cross.filter(
-        (pl.col("max_len") > 0) &
-        (pl.col("distance").cast(pl.Float64) / pl.col("max_len").cast(pl.Float64) <= max_dist_frac)
-    )
-
-    if matches.height == 0:
-        print(f"Singleton reassignment: 0 of {n_singletons} singletons matched "
-              f"any non-singleton centroid (min-seq-id={min_seq_id})")
-        return clusters
-
-    # Pick best match per singleton: lowest normalized distance, then largest cluster
-    matches = matches.with_columns(
-        (pl.col("distance").cast(pl.Float64) / pl.col("max_len").cast(pl.Float64)).alias("norm_dist")
-    )
-    best_matches = (
-        matches
-        .sort(["norm_dist", "rep_size"], descending=[False, True])
-        .group_by("member_key").first()
-    )
-
-    # Log reassignments (first 10)
-    for row in best_matches.head(10).iter_rows(named=True):
-        print(f"  reassign {row['member_key']} -> centroid {row['clusterId']} "
-              f"(dist={row['distance']}, norm_dist={row['norm_dist']:.4f}, "
-              f"seq='{row['member_seq']}', centroid_seq='{row['centroid_seq']}', "
-              f"cluster_size={row['rep_size']})")
-    if best_matches.height > 10:
-        print(f"  ... and {best_matches.height - 10} more reassignments")
-
-    # Apply reassignments to clusters DataFrame
-    reassign_df = best_matches.select(
-        pl.col("member_key").alias("r_key"),
-        pl.col("clusterId").alias("new_clusterId")
-    )
-    clusters = clusters.join(reassign_df, left_on="clonotypeKey", right_on="r_key", how="left")
-    clusters = clusters.with_columns(
-        pl.coalesce(pl.col("new_clusterId"), pl.col("clusterId")).alias("clusterId")
-    ).drop("new_clusterId")
-
-    print(f"Singleton reassignment: {best_matches.height} of {n_singletons} singletons "
-          f"reassigned to existing clusters (min-seq-id={min_seq_id})")
-    return clusters
 
 
 # --- Reassign singleton representatives to nearby non-singleton clusters ---

--- a/software/src/reassign_singletons.py
+++ b/software/src/reassign_singletons.py
@@ -1,192 +1,213 @@
 """Singleton reassignment for high-precision clustering.
 
-Reassign singleton cluster representatives to nearby non-singleton clusters. For each
-centroid it prunes to length-compatible singletons, applies a bounded Levenshtein
-prefilter, then an exact recheck, keeping only a running best-per-singleton, so peak
-memory is O(#singletons). In its own module so it can be unit-tested without running
-the whole process_results.py pipeline.
+MMseqs2's k-mer prefilter (k=5) misses valid matches for short sequences (5-7 aa),
+leaving them as false singletons. This folds each singleton into the nearest
+non-singleton cluster whose representative is within the identity threshold.
+
+The old all-pairs cross join overflowed polars' 2^32 row cap on large repertoires.
+Instead this walks centroids one at a time through a three-stage funnel, keeping
+only a running best-per-singleton, so peak memory is O(#singletons).
 """
 import math
 
 import polars as pl
 import polars_ds as pds
 
-# Default cap on accumulated match rows before reducing to the running
-# best-per-singleton. Bounds peak memory; the reassignment result is identical
-# for any value (correctness is independent of it). Exposed as the `flush_rows`
-# argument so tests can force the reduction path on small inputs.
+# Preferred first: the trimmed sequence wins over untrimmed when both exist.
+SEQ_COLUMNS = ("trimmed_fullSequence", "fullSequence")
+
+# Memory bound only: candidate rows accumulated before reducing to the running
+# best. The result is identical for any value (see _RunningBest).
 FLUSH_ROWS = 2_000_000
 
 
 def reassign_singletons(clusters: pl.DataFrame, cloneTable: pl.DataFrame,
                         min_seq_id: float, flush_rows: int = FLUSH_ROWS) -> pl.DataFrame:
-    """Reassign singleton cluster representatives to nearby non-singleton clusters.
+    """Fold singleton clusters into a near-enough non-singleton cluster.
 
-    MMseqs2 kmer prefilter (k=5) can miss valid matches for short sequences (5-7 aa),
-    leaving them as incorrect singletons. This checks each singleton representative
-    against non-singleton centroids within the identity threshold.
-
-    For each centroid we
-      (1) keep only length-compatible singletons -- a match needs
-          |len_s - len_c| <= (1 - min_seq_id) * max_len, so others provably can't match;
-      (2) run pds.filter_by_levenshtein as a generous bounded prefilter (never drops a
-          true match; a fused, early-exiting distance check with no intermediate frame);
-      (3) apply the exact normalized recheck.
-    Only a RUNNING best-per-singleton is kept (periodically reduced), so peak memory is
-    O(#singletons) regardless of how many pairs match. Each singleton's best match is the
-    closest centroid, then the largest cluster.
-
-    `flush_rows` caps how many candidate rows accumulate before the running best is
-    reduced (a memory bound); it never changes the result.
-
-    Returns the (possibly updated) clusters DataFrame.
+    A singleton is reassigned to the centroid within `1 - min_seq_id` normalized
+    Levenshtein distance, preferring the closest, then the largest, then the
+    lowest-id cluster. Returns `clusters` with `clusterId` updated in place; a
+    no-op (with an explanatory print) when there is nothing to reassign.
     """
-    seq_col = 'trimmed_fullSequence' if 'trimmed_fullSequence' in cloneTable.columns else (
-        'fullSequence' if 'fullSequence' in cloneTable.columns else None)
-
-    if not seq_col:
+    seq_col = next((c for c in SEQ_COLUMNS if c in cloneTable.columns), None)
+    if seq_col is None:
         print("Singleton reassignment: skipped (no sequence columns available)")
         return clusters
 
-    # Count representatives per cluster (before dedup expansion)
-    rep_sizes = clusters.group_by("clusterId").agg(pl.len().alias("rep_size"))
-    singleton_ids = rep_sizes.filter(pl.col("rep_size") == 1)["clusterId"]
-    non_singleton_centroids = rep_sizes.filter(pl.col("rep_size") > 1)
-
-    if singleton_ids.len() == 0 or non_singleton_centroids.height == 0:
-        print(f"Singleton reassignment: skipped "
-              f"({'no singletons' if singleton_ids.len() == 0 else 'no non-singleton clusters to reassign to'})")
+    singletons, centroids = _split_by_size(clusters, cloneTable, seq_col)
+    if singletons.height == 0 or centroids.height == 0:
+        why = "no singletons" if singletons.height == 0 else "no non-singleton clusters to reassign to"
+        print(f"Singleton reassignment: skipped ({why})")
         return clusters
 
-    # Sequence lookup from cloneTable (keyed by clonotypeKey)
-    seq_df = (
-        cloneTable.select(["clonotypeKey", seq_col])
-        .unique("clonotypeKey", keep="first")
-    )
+    print(f"Singleton reassignment: checking {singletons.height} singletons "
+          f"against {centroids.height} centroids...")
 
-    # Singleton members with their sequences (length precomputed once for the band prefilter)
-    singleton_df = (
-        clusters.filter(pl.col("clusterId").is_in(singleton_ids))
-        .select(pl.col("clonotypeKey").alias("member_key"))
-        .join(
-            seq_df.select(
-                pl.col("clonotypeKey").alias("member_key"),
-                pl.col(seq_col).alias("member_seq")
-            ),
-            on="member_key", how="inner"
-        )
-        .with_columns(pl.col("member_seq").str.len_chars().cast(pl.Int64).alias("member_len"))
-    )
-
-    # Non-singleton centroids with their sequences and sizes
-    centroid_df = (
-        non_singleton_centroids
-        .select(["clusterId", "rep_size"])
-        .join(
-            seq_df.select(
-                pl.col("clonotypeKey").alias("clusterId"),
-                pl.col(seq_col).alias("centroid_seq")
-            ),
-            on="clusterId", how="inner"
-        )
-    )
-    rep_dtype = non_singleton_centroids.schema["rep_size"]
-
-    n_singletons = singleton_df.height
-    n_centroids = centroid_df.height
-    print(f"Singleton reassignment: checking {n_singletons} singletons against {n_centroids} centroids...")
-
-    max_dist_frac = 1.0 - min_seq_id
-    # Largest singleton length overall, computed ONCE (not per centroid). Every band
-    # member is <= this, so it is a safe (generous) upper bound for the Levenshtein
-    # prefilter that never drops a true match -- and it avoids an eager .max().item()
-    # query inside the per-centroid loop.
-    max_len_all = int(singleton_df.select(pl.col("member_len").max()).item()) if singleton_df.height else 0
-
-    def select_best(matches):
-        # Closest centroid (lowest normalized distance), then largest cluster, then
-        # smallest clusterId as a deterministic tie-break (a singleton matches a given
-        # cluster at most once, so this key is unique per singleton -> reproducible pick).
-        return (matches.sort(["norm_dist", "rep_size", "clusterId"], descending=[False, True, False])
-                .group_by("member_key").first()
-                .select("member_key", "clusterId", "rep_size", "distance", "norm_dist"))
-
-    best = None
-    pending = []
-    pending_rows = 0
-    for c in centroid_df.iter_rows(named=True):
-        c_seq = c["centroid_seq"]
-        Lc = len(c_seq)
-        if Lc == 0:
-            continue  # empty centroid can only "match" empty singletons (excluded by max_len>0)
-
-        # (1) length-band prefilter (exact necessary condition; can only over-keep).
-        band = singleton_df.filter(
-            (pl.col("member_len") - Lc).abs().cast(pl.Float64)
-            <= max_dist_frac * pl.max_horizontal(pl.col("member_len"), pl.lit(Lc)).cast(pl.Float64)
-        )
-        if band.height == 0:
-            continue
-
-        # (2) generous bounded prefilter: bound from max_len_all (>= this band's max
-        # length), so it never drops a real match; extras are removed by the exact recheck.
-        bound = int(math.floor(max_dist_frac * max(max_len_all, Lc)))
-        # pl.lit(c_seq): filter_by_levenshtein treats a bare str as a COLUMN NAME (polars_ds
-        # 0.10.2), so the centroid must be a literal or it raises ColumnNotFoundError.
-        pref = band.filter(pds.filter_by_levenshtein("member_seq", pl.lit(c_seq), bound, parallel=True))
-        if pref.height == 0:
-            continue
-
-        # (3) exact normalized recheck. Compute norm_dist once, then reuse it for both
-        # the filter and the output row (no redundant division / casting).
-        exact = pref.with_columns(
-            pds.str_leven(pl.col("member_seq"), pl.lit(c_seq), return_sim=False).alias("distance"),
-            pl.max_horizontal(pl.col("member_len"), pl.lit(Lc)).alias("max_len"),
-        ).with_columns(
-            (pl.col("distance").cast(pl.Float64) / pl.col("max_len").cast(pl.Float64)).alias("norm_dist"),
-        ).filter(
-            (pl.col("max_len") > 0) & (pl.col("norm_dist") <= max_dist_frac)
-        )
-        if exact.height == 0:
-            continue
-
-        cur = exact.with_columns(
-            pl.lit(c["clusterId"]).alias("clusterId"),
-            pl.lit(c["rep_size"], dtype=rep_dtype).alias("rep_size"),
-        ).select("member_key", "clusterId", "rep_size", "distance", "norm_dist")
-        pending.append(cur)
-        pending_rows += cur.height
-        if pending_rows >= flush_rows:
-            best = select_best(pl.concat(([best] if best is not None else []) + pending))
-            pending, pending_rows = [], 0
-    if pending:
-        best = select_best(pl.concat(([best] if best is not None else []) + pending))
-
-    if best is None or best.height == 0:
-        print(f"Singleton reassignment: 0 of {n_singletons} singletons matched "
+    best = _best_match_per_singleton(singletons, centroids, 1.0 - min_seq_id, flush_rows)
+    if best.height == 0:
+        print(f"Singleton reassignment: 0 of {singletons.height} singletons matched "
               f"any non-singleton centroid (min-seq-id={min_seq_id})")
         return clusters
 
-    best_matches = best
+    _log_reassignments(best)
+    print(f"Singleton reassignment: {best.height} of {singletons.height} singletons "
+          f"reassigned to existing clusters (min-seq-id={min_seq_id})")
+    return _apply_reassignments(clusters, best)
 
-    # Log reassignments (first 10)
-    for row in best_matches.head(10).iter_rows(named=True):
+
+def _split_by_size(clusters: pl.DataFrame, cloneTable: pl.DataFrame,
+                   seq_col: str) -> tuple[pl.DataFrame, pl.DataFrame]:
+    """Split representatives into singletons and centroids, joined to their sequence.
+
+    A cluster's representative is the clonotype whose key equals the clusterId.
+    Returns (singletons[member_key, member_seq, member_len],
+             centroids[clusterId, rep_size, centroid_seq]).
+    """
+    seq = cloneTable.select("clonotypeKey", seq_col).unique("clonotypeKey", keep="first")
+    rep_size = clusters.group_by("clusterId").agg(pl.len().alias("rep_size"))
+
+    singletons = (
+        clusters.join(rep_size.filter(pl.col("rep_size") == 1).select("clusterId"),
+                      on="clusterId", how="semi")
+        .join(seq, on="clonotypeKey", how="inner")
+        .select(
+            pl.col("clonotypeKey").alias("member_key"),
+            pl.col(seq_col).alias("member_seq"),
+            pl.col(seq_col).str.len_chars().cast(pl.Int64).alias("member_len"),
+        )
+    )
+    centroids = (
+        rep_size.filter(pl.col("rep_size") > 1)
+        .join(seq.rename({"clonotypeKey": "clusterId", seq_col: "centroid_seq"}),
+              on="clusterId", how="inner")
+    )
+    return singletons, centroids
+
+
+def _best_match_per_singleton(singletons: pl.DataFrame, centroids: pl.DataFrame,
+                              max_dist_frac: float, flush_rows: int) -> pl.DataFrame:
+    """Best qualifying centroid per singleton, or an empty frame if none match."""
+    # Loop-invariant upper bound for the per-centroid prefilter (see _match_centroid).
+    max_len_all = int(singletons.select(pl.col("member_len").max()).item())
+    rep_dtype = centroids.schema["rep_size"]
+
+    running = _RunningBest(flush_rows)
+    for centroid in centroids.iter_rows(named=True):
+        if (candidates := _match_centroid(singletons, centroid, max_dist_frac,
+                                          max_len_all, rep_dtype)) is not None:
+            running.add(candidates)
+    return running.result()
+
+
+def _match_centroid(singletons: pl.DataFrame, centroid: dict, max_dist_frac: float,
+                    max_len_all: int, rep_dtype: pl.DataType) -> pl.DataFrame | None:
+    """Singletons matching one centroid, or None if none do.
+
+    Three stages, each only over-keeps relative to the next, so survivors are exactly
+    the pairs the old cross-join-then-filter produced:
+      (1) length band       -- a match needs |Ls - Lc| <= frac * max(Ls, Lc);
+      (2) bounded Levenshtein -- generous prefilter, early-exiting, no full matrix;
+      (3) exact recheck      -- distance / max_len <= frac.
+    """
+    centroid_seq = centroid["centroid_seq"]
+    centroid_len = len(centroid_seq)
+    if centroid_len == 0:
+        return None  # empty centroid only matches empty singletons, dropped by max_len > 0
+
+    band = singletons.filter(
+        (pl.col("member_len") - centroid_len).abs()
+        <= max_dist_frac * pl.max_horizontal("member_len", pl.lit(centroid_len))
+    )
+    if band.height == 0:
+        return None
+
+    # bound uses max_len_all (>= this pair's max_len), so it never drops a true match.
+    # polars_ds 0.10.2 reads a bare str as a column name -> the centroid must be pl.lit.
+    bound = math.floor(max_dist_frac * max(max_len_all, centroid_len))
+    pref = band.filter(pds.filter_by_levenshtein("member_seq", pl.lit(centroid_seq), bound, parallel=True))
+    if pref.height == 0:
+        return None
+
+    matched = (
+        pref.with_columns(
+            pds.str_leven("member_seq", pl.lit(centroid_seq), return_sim=False).alias("distance"),
+            pl.max_horizontal("member_len", pl.lit(centroid_len)).alias("max_len"),
+        )
+        .with_columns((pl.col("distance") / pl.col("max_len")).alias("norm_dist"))
+        .filter((pl.col("max_len") > 0) & (pl.col("norm_dist") <= max_dist_frac))
+    )
+    if matched.height == 0:
+        return None
+
+    return matched.select(
+        "member_key",
+        pl.lit(centroid["clusterId"]).alias("clusterId"),
+        pl.lit(centroid["rep_size"], dtype=rep_dtype).alias("rep_size"),
+        "distance",
+        "norm_dist",
+    )
+
+
+class _RunningBest:
+    """Running best match per singleton, without holding every candidate.
+
+    Candidates accumulate until they exceed flush_rows, then collapse to one row per
+    singleton. Chunked reduction equals a single reduction because the ranking key is
+    a strict total order and each singleton matches a given cluster at most once.
+    """
+
+    def __init__(self, flush_rows: int):
+        self._flush_rows = flush_rows
+        self._best = None
+        self._pending = []
+        self._pending_rows = 0
+
+    def add(self, candidates: pl.DataFrame) -> None:
+        self._pending.append(candidates)
+        self._pending_rows += candidates.height
+        if self._pending_rows >= self._flush_rows:
+            self._reduce()
+
+    def result(self) -> pl.DataFrame:
+        self._reduce()
+        return self._best if self._best is not None else pl.DataFrame()
+
+    def _reduce(self) -> None:
+        if not self._pending:
+            return
+        frames = self._pending if self._best is None else [self._best, *self._pending]
+        self._best = _pick_best(pl.concat(frames))
+        self._pending, self._pending_rows = [], 0
+
+
+def _pick_best(candidates: pl.DataFrame) -> pl.DataFrame:
+    """One row per singleton: closest centroid, then largest, then lowest clusterId."""
+    return (
+        candidates
+        .sort(["norm_dist", "rep_size", "clusterId"], descending=[False, True, False])
+        .group_by("member_key").first()
+    )
+
+
+def _log_reassignments(best: pl.DataFrame, limit: int = 10) -> None:
+    # Sort for a stable log sample (group_by output order is not deterministic);
+    # closest reassignments first.
+    shown = best.sort(["norm_dist", "member_key"])
+    for row in shown.head(limit).iter_rows(named=True):
         print(f"  reassign {row['member_key']} -> centroid {row['clusterId']} "
               f"(dist={row['distance']}, norm_dist={row['norm_dist']:.4f}, "
               f"cluster_size={row['rep_size']})")
-    if best_matches.height > 10:
-        print(f"  ... and {best_matches.height - 10} more reassignments")
+    if best.height > limit:
+        print(f"  ... and {best.height - limit} more reassignments")
 
-    # Apply reassignments to clusters DataFrame
-    reassign_df = best_matches.select(
-        pl.col("member_key").alias("r_key"),
-        pl.col("clusterId").alias("new_clusterId")
+
+def _apply_reassignments(clusters: pl.DataFrame, best: pl.DataFrame) -> pl.DataFrame:
+    """Point every reassigned singleton's rows at its new clusterId."""
+    reassign = best.select("member_key", pl.col("clusterId").alias("new_clusterId"))
+    return (
+        clusters
+        .join(reassign, left_on="clonotypeKey", right_on="member_key", how="left")
+        .with_columns(pl.coalesce("new_clusterId", "clusterId").alias("clusterId"))
+        .drop("new_clusterId")
     )
-    clusters = clusters.join(reassign_df, left_on="clonotypeKey", right_on="r_key", how="left")
-    clusters = clusters.with_columns(
-        pl.coalesce(pl.col("new_clusterId"), pl.col("clusterId")).alias("clusterId")
-    ).drop("new_clusterId")
-
-    print(f"Singleton reassignment: {best_matches.height} of {n_singletons} singletons "
-          f"reassigned to existing clusters (min-seq-id={min_seq_id})")
-    return clusters

--- a/software/src/reassign_singletons.py
+++ b/software/src/reassign_singletons.py
@@ -1,0 +1,183 @@
+"""Singleton reassignment for high-precision clustering.
+
+Reassign singleton cluster representatives to nearby non-singleton clusters. For each
+centroid it prunes to length-compatible singletons, applies a bounded Levenshtein
+prefilter, then an exact recheck, keeping only a running best-per-singleton, so peak
+memory is O(#singletons). In its own module so it can be unit-tested without running
+the whole process_results.py pipeline.
+"""
+import math
+
+import polars as pl
+import polars_ds as pds
+
+# Default cap on accumulated match rows before reducing to the running
+# best-per-singleton. Bounds peak memory; the reassignment result is identical
+# for any value (correctness is independent of it). Exposed as the `flush_rows`
+# argument so tests can force the reduction path on small inputs.
+FLUSH_ROWS = 2_000_000
+
+
+def reassign_singletons(clusters: pl.DataFrame, cloneTable: pl.DataFrame,
+                        min_seq_id: float, flush_rows: int = FLUSH_ROWS) -> pl.DataFrame:
+    """Reassign singleton cluster representatives to nearby non-singleton clusters.
+
+    MMseqs2 kmer prefilter (k=5) can miss valid matches for short sequences (5-7 aa),
+    leaving them as incorrect singletons. This checks each singleton representative
+    against non-singleton centroids within the identity threshold.
+
+    For each centroid we
+      (1) keep only length-compatible singletons -- a match needs
+          |len_s - len_c| <= (1 - min_seq_id) * max_len, so others provably can't match;
+      (2) run pds.filter_by_levenshtein as a generous bounded prefilter (never drops a
+          true match; a fused, early-exiting distance check with no intermediate frame);
+      (3) apply the exact normalized recheck.
+    Only a RUNNING best-per-singleton is kept (periodically reduced), so peak memory is
+    O(#singletons) regardless of how many pairs match. Each singleton's best match is the
+    closest centroid, then the largest cluster.
+
+    `flush_rows` caps how many candidate rows accumulate before the running best is
+    reduced (a memory bound); it never changes the result.
+
+    Returns the (possibly updated) clusters DataFrame.
+    """
+    seq_col = 'trimmed_fullSequence' if 'trimmed_fullSequence' in cloneTable.columns else (
+        'fullSequence' if 'fullSequence' in cloneTable.columns else None)
+
+    if not seq_col:
+        print("Singleton reassignment: skipped (no sequence columns available)")
+        return clusters
+
+    # Count representatives per cluster (before dedup expansion)
+    rep_sizes = clusters.group_by("clusterId").agg(pl.len().alias("rep_size"))
+    singleton_ids = rep_sizes.filter(pl.col("rep_size") == 1)["clusterId"]
+    non_singleton_centroids = rep_sizes.filter(pl.col("rep_size") > 1)
+
+    if singleton_ids.len() == 0 or non_singleton_centroids.height == 0:
+        print(f"Singleton reassignment: skipped "
+              f"({'no singletons' if singleton_ids.len() == 0 else 'no non-singleton clusters to reassign to'})")
+        return clusters
+
+    # Sequence lookup from cloneTable (keyed by clonotypeKey)
+    seq_df = (
+        cloneTable.select(["clonotypeKey", seq_col])
+        .unique("clonotypeKey", keep="first")
+    )
+
+    # Singleton members with their sequences (length precomputed once for the band prefilter)
+    singleton_df = (
+        clusters.filter(pl.col("clusterId").is_in(singleton_ids))
+        .select(pl.col("clonotypeKey").alias("member_key"))
+        .join(
+            seq_df.select(
+                pl.col("clonotypeKey").alias("member_key"),
+                pl.col(seq_col).alias("member_seq")
+            ),
+            on="member_key", how="inner"
+        )
+        .with_columns(pl.col("member_seq").str.len_chars().cast(pl.Int64).alias("member_len"))
+    )
+
+    # Non-singleton centroids with their sequences and sizes
+    centroid_df = (
+        non_singleton_centroids
+        .select(["clusterId", "rep_size"])
+        .join(
+            seq_df.select(
+                pl.col("clonotypeKey").alias("clusterId"),
+                pl.col(seq_col).alias("centroid_seq")
+            ),
+            on="clusterId", how="inner"
+        )
+    )
+    rep_dtype = non_singleton_centroids.schema["rep_size"]
+
+    n_singletons = singleton_df.height
+    n_centroids = centroid_df.height
+    print(f"Singleton reassignment: checking {n_singletons} singletons against {n_centroids} centroids...")
+
+    max_dist_frac = 1.0 - min_seq_id
+
+    def select_best(matches):
+        # Closest centroid (lowest normalized distance), then largest cluster; one row per singleton.
+        return (matches.sort(["norm_dist", "rep_size"], descending=[False, True])
+                .group_by("member_key").first()
+                .select("member_key", "clusterId", "rep_size", "distance", "norm_dist"))
+
+    best = None
+    pending = []
+    pending_rows = 0
+    for c in centroid_df.iter_rows(named=True):
+        c_seq = c["centroid_seq"]
+        Lc = len(c_seq)
+        if Lc == 0:
+            continue  # empty centroid can only "match" empty singletons (excluded by max_len>0)
+
+        # (1) length-band prefilter (exact necessary condition; can only over-keep).
+        band = singleton_df.filter(
+            (pl.col("member_len") - Lc).abs().cast(pl.Float64)
+            <= max_dist_frac * pl.max_horizontal(pl.col("member_len"), pl.lit(Lc)).cast(pl.Float64)
+        )
+        if band.height == 0:
+            continue
+
+        # (2) generous bounded prefilter: bound = largest allowed edits over the band, so it
+        # never drops a real match; a few extras are removed by the exact recheck below.
+        max_len_band = int(band.select(pl.col("member_len").max()).item())
+        bound = int(math.floor(max_dist_frac * max(max_len_band, Lc)))
+        pref = band.filter(pds.filter_by_levenshtein("member_seq", pl.lit(c_seq), bound, parallel=True))
+        if pref.height == 0:
+            continue
+
+        # (3) exact normalized recheck.
+        exact = pref.with_columns(
+            pds.str_leven(pl.col("member_seq"), pl.lit(c_seq), return_sim=False).alias("distance"),
+            pl.max_horizontal(pl.col("member_len"), pl.lit(Lc)).alias("max_len"),
+        ).filter(
+            (pl.col("max_len") > 0) &
+            (pl.col("distance").cast(pl.Float64) / pl.col("max_len").cast(pl.Float64) <= max_dist_frac)
+        )
+        if exact.height == 0:
+            continue
+
+        cur = exact.with_columns(
+            (pl.col("distance").cast(pl.Float64) / pl.col("max_len").cast(pl.Float64)).alias("norm_dist"),
+            pl.lit(c["clusterId"]).alias("clusterId"),
+            pl.lit(c["rep_size"], dtype=rep_dtype).alias("rep_size"),
+        ).select("member_key", "clusterId", "rep_size", "distance", "norm_dist")
+        pending.append(cur)
+        pending_rows += cur.height
+        if pending_rows >= flush_rows:
+            best = select_best(pl.concat(([best] if best is not None else []) + pending))
+            pending, pending_rows = [], 0
+    if pending:
+        best = select_best(pl.concat(([best] if best is not None else []) + pending))
+
+    if best is None or best.height == 0:
+        print(f"Singleton reassignment: 0 of {n_singletons} singletons matched "
+              f"any non-singleton centroid (min-seq-id={min_seq_id})")
+        return clusters
+
+    best_matches = best
+
+    # Log reassignments (first 10)
+    for row in best_matches.head(10).iter_rows(named=True):
+        print(f"  reassign {row['member_key']} -> centroid {row['clusterId']} "
+              f"(dist={row['distance']}, norm_dist={row['norm_dist']:.4f}, "
+              f"cluster_size={row['rep_size']})")
+    if best_matches.height > 10:
+        print(f"  ... and {best_matches.height - 10} more reassignments")
+
+    # Apply reassignments to clusters DataFrame
+    reassign_df = best_matches.select(
+        pl.col("member_key").alias("r_key"),
+        pl.col("clusterId").alias("new_clusterId")
+    )
+    clusters = clusters.join(reassign_df, left_on="clonotypeKey", right_on="r_key", how="left")
+    clusters = clusters.with_columns(
+        pl.coalesce(pl.col("new_clusterId"), pl.col("clusterId")).alias("clusterId")
+    ).drop("new_clusterId")
+
+    print(f"Singleton reassignment: {best_matches.height} of {n_singletons} singletons "
+          f"reassigned to existing clusters (min-seq-id={min_seq_id})")
+    return clusters

--- a/software/src/reassign_singletons.py
+++ b/software/src/reassign_singletons.py
@@ -97,10 +97,17 @@ def reassign_singletons(clusters: pl.DataFrame, cloneTable: pl.DataFrame,
     print(f"Singleton reassignment: checking {n_singletons} singletons against {n_centroids} centroids...")
 
     max_dist_frac = 1.0 - min_seq_id
+    # Largest singleton length overall, computed ONCE (not per centroid). Every band
+    # member is <= this, so it is a safe (generous) upper bound for the Levenshtein
+    # prefilter that never drops a true match -- and it avoids an eager .max().item()
+    # query inside the per-centroid loop.
+    max_len_all = int(singleton_df.select(pl.col("member_len").max()).item()) if singleton_df.height else 0
 
     def select_best(matches):
-        # Closest centroid (lowest normalized distance), then largest cluster; one row per singleton.
-        return (matches.sort(["norm_dist", "rep_size"], descending=[False, True])
+        # Closest centroid (lowest normalized distance), then largest cluster, then
+        # smallest clusterId as a deterministic tie-break (a singleton matches a given
+        # cluster at most once, so this key is unique per singleton -> reproducible pick).
+        return (matches.sort(["norm_dist", "rep_size", "clusterId"], descending=[False, True, False])
                 .group_by("member_key").first()
                 .select("member_key", "clusterId", "rep_size", "distance", "norm_dist"))
 
@@ -121,27 +128,29 @@ def reassign_singletons(clusters: pl.DataFrame, cloneTable: pl.DataFrame,
         if band.height == 0:
             continue
 
-        # (2) generous bounded prefilter: bound = largest allowed edits over the band, so it
-        # never drops a real match; a few extras are removed by the exact recheck below.
-        max_len_band = int(band.select(pl.col("member_len").max()).item())
-        bound = int(math.floor(max_dist_frac * max(max_len_band, Lc)))
+        # (2) generous bounded prefilter: bound from max_len_all (>= this band's max
+        # length), so it never drops a real match; extras are removed by the exact recheck.
+        bound = int(math.floor(max_dist_frac * max(max_len_all, Lc)))
+        # pl.lit(c_seq): filter_by_levenshtein treats a bare str as a COLUMN NAME (polars_ds
+        # 0.10.2), so the centroid must be a literal or it raises ColumnNotFoundError.
         pref = band.filter(pds.filter_by_levenshtein("member_seq", pl.lit(c_seq), bound, parallel=True))
         if pref.height == 0:
             continue
 
-        # (3) exact normalized recheck.
+        # (3) exact normalized recheck. Compute norm_dist once, then reuse it for both
+        # the filter and the output row (no redundant division / casting).
         exact = pref.with_columns(
             pds.str_leven(pl.col("member_seq"), pl.lit(c_seq), return_sim=False).alias("distance"),
             pl.max_horizontal(pl.col("member_len"), pl.lit(Lc)).alias("max_len"),
+        ).with_columns(
+            (pl.col("distance").cast(pl.Float64) / pl.col("max_len").cast(pl.Float64)).alias("norm_dist"),
         ).filter(
-            (pl.col("max_len") > 0) &
-            (pl.col("distance").cast(pl.Float64) / pl.col("max_len").cast(pl.Float64) <= max_dist_frac)
+            (pl.col("max_len") > 0) & (pl.col("norm_dist") <= max_dist_frac)
         )
         if exact.height == 0:
             continue
 
         cur = exact.with_columns(
-            (pl.col("distance").cast(pl.Float64) / pl.col("max_len").cast(pl.Float64)).alias("norm_dist"),
             pl.lit(c["clusterId"]).alias("clusterId"),
             pl.lit(c["rep_size"], dtype=rep_dtype).alias("rep_size"),
         ).select("member_key", "clusterId", "rep_size", "distance", "norm_dist")

--- a/software/tests/test_reassign_singletons.py
+++ b/software/tests/test_reassign_singletons.py
@@ -102,6 +102,17 @@ def test_larger_cluster_breaks_distance_tie():
     assert cluster_of(out, "SNG") == "REP_BIG"
 
 
+def test_equal_distance_equal_size_tie_breaks_on_clusterid():
+    # SNG=BASE is 1 edit from each rep (A1 at pos 5, A2 at pos 1) and both clusters are
+    # size 2 -> equal norm_dist AND equal rep_size. Must deterministically pick the
+    # smaller clusterId ("REP_A"), regardless of the order the buckets are supplied.
+    for order in ([("REP_A", A1, 2), ("REP_B", A2, 2)],
+                  [("REP_B", A2, 2), ("REP_A", A1, 2)]):
+        clusters, cloneTable = build_frames(buckets=order, singletons=[("SNG", BASE)])
+        out = reassign_singletons(clusters, cloneTable, MIN_SEQ_ID)
+        assert cluster_of(out, "SNG") == "REP_A"
+
+
 def test_mixed_batch_of_singletons():
     clusters, cloneTable = build_frames(
         buckets=[("REP_BASE", BASE, 3)],
@@ -139,22 +150,46 @@ def test_no_sequence_column_is_noop():
 
 
 @pytest.mark.slow
-def test_scaled_runs_without_materializing_all_pairs():
-    """Many singletons x many centroids: must complete with bounded memory and
-    return a well-formed frame."""
+def test_scaled_matching_flows_through_all_stages_and_flush():
+    """At scale, with real matches driving every stage and the flush/reduction path.
+
+    200 families, each a centroid plus 10 singleton variants that are 1 edit from the
+    family base (same length, so the length band admits them). Every singleton matches
+    its own family's centroid, so ~2000 candidates flow through filter_by_levenshtein,
+    the exact recheck, and accumulation into `pending`; a small `flush_rows` forces
+    several reductions. Asserts each singleton is reassigned to its own family.
+    """
     rng = random.Random(0)
     aa = "ACDEFGHIKLMNPQRSTVWY"
+    L, n_families, per_family = 12, 200, 10
 
-    def rseq(n):
-        return "".join(rng.choice(aa) for _ in range(n))
+    def rseq():
+        return "".join(rng.choice(aa) for _ in range(L))
 
-    buckets = [(f"B{j}", rseq(12), 2) for j in range(2000)]
-    singletons = [(f"S{i}", rseq(9)) for i in range(2000)]
+    def one_edit(seq):
+        i = rng.randrange(L)
+        repl = rng.choice(aa)
+        while repl == seq[i]:
+            repl = rng.choice(aa)
+        return seq[:i] + repl + seq[i + 1:]
+
+    buckets, singletons, expected = [], [], {}
+    for f in range(n_families):
+        base = rseq()
+        buckets.append((f"C{f}", base, 2))
+        for k in range(per_family):
+            key = f"S{f}_{k}"
+            singletons.append((key, one_edit(base)))
+            expected[key] = f"C{f}"
     clusters, cloneTable = build_frames(buckets, singletons)
-    out = reassign_singletons(clusters, cloneTable, MIN_SEQ_ID)
-    # every original row is preserved (only clusterId may change)
+
+    # small flush_rows -> the 2000 matches trigger several running-best reductions
+    out = reassign_singletons(clusters, cloneTable, MIN_SEQ_ID, flush_rows=500)
+
     assert out.height == clusters.height
-    assert set(out.columns) == {"clusterId", "clonotypeKey"}
+    assign = dict(zip(out["clonotypeKey"].to_list(), out["clusterId"].to_list()))
+    for key, want in expected.items():
+        assert assign[key] == want
 
 
 @pytest.mark.parametrize("flush_rows", [1, 7, 25, 101, 10**9])

--- a/software/tests/test_reassign_singletons.py
+++ b/software/tests/test_reassign_singletons.py
@@ -1,0 +1,185 @@
+"""Regression tests for reassign_singletons.
+
+Each case builds small `clusters` / `cloneTable` frames whose correct outcome is
+known by construction, so the tests need no large data.
+
+Contract under test:
+  - a singleton within (1 - min_seq_id) normalized Levenshtein of a non-singleton
+    cluster's representative is reassigned to it;
+  - among several qualifying clusters, the CLOSEST wins; ties break toward the
+    LARGER cluster;
+  - singletons matching nothing stay as-is; degenerate inputs are no-ops.
+"""
+from __future__ import annotations
+
+import random
+
+import polars as pl
+import pytest
+
+from reassign_singletons import reassign_singletons
+
+MIN_SEQ_ID = 0.8  # allow up to 20% differences
+
+# --- reference sequences (length 12 -> up to 2 edits pass 0.8 identity) --------
+BASE = "CASSLGETQYFW"
+A1 = "CASSLAETQYFW"   # 1 edit from BASE (pos 5 G->A)
+A2 = "CDSSLGETQYFW"   # 1 edit from BASE (pos 1 A->D)  -- different position
+FAR2 = "CASSLAETQKKW"  # 2 edits from A1 (pos 9,10)   -- used as a farther centroid
+FAR = "KKKKKKKKKKKK"   # every position differs from BASE -> never matches
+
+
+def build_frames(buckets, singletons):
+    """buckets: [(rep_key, seq, size)]; singletons: [(key, seq)].
+
+    Produces (clusters, cloneTable) shaped like the real pipeline inputs:
+    a bucket contributes `size` rows to `clusters` (representative + members),
+    the representative's sequence is what reassignment compares against.
+    """
+    cl_cluster, cl_clone, ct_key, ct_seq = [], [], [], []
+    for rep_key, seq, size in buckets:
+        cl_cluster.append(rep_key)
+        cl_clone.append(rep_key)
+        ct_key.append(rep_key)
+        ct_seq.append(seq)
+        for i in range(size - 1):
+            mk = f"{rep_key}_m{i}"
+            cl_cluster.append(rep_key)
+            cl_clone.append(mk)
+            ct_key.append(mk)
+            ct_seq.append(seq)
+    for key, seq in singletons:
+        cl_cluster.append(key)
+        cl_clone.append(key)
+        ct_key.append(key)
+        ct_seq.append(seq)
+    clusters = pl.DataFrame({"clusterId": cl_cluster, "clonotypeKey": cl_clone})
+    cloneTable = pl.DataFrame({"clonotypeKey": ct_key, "trimmed_fullSequence": ct_seq})
+    return clusters, cloneTable
+
+
+def cluster_of(result: pl.DataFrame, key: str) -> str:
+    """Which clusterId a given clonotypeKey ended up in."""
+    return result.filter(pl.col("clonotypeKey") == key)["clusterId"].to_list()[0]
+
+
+def test_near_singleton_is_reassigned():
+    clusters, cloneTable = build_frames(
+        buckets=[("REP_BASE", BASE, 2)],
+        singletons=[("SNG", A1)],  # 1 edit from BASE -> norm 1/12 ~= 0.083 <= 0.2
+    )
+    out = reassign_singletons(clusters, cloneTable, MIN_SEQ_ID)
+    assert cluster_of(out, "SNG") == "REP_BASE"
+
+
+def test_far_singleton_is_kept():
+    clusters, cloneTable = build_frames(
+        buckets=[("REP_BASE", BASE, 2)],
+        singletons=[("SNG", FAR)],  # every position differs -> norm 1.0 > 0.2
+    )
+    out = reassign_singletons(clusters, cloneTable, MIN_SEQ_ID)
+    assert cluster_of(out, "SNG") == "SNG"  # unchanged
+
+
+def test_closest_cluster_wins_over_distance():
+    # SNG=A1 is 1 edit from REP_BASE and 2 edits from REP_FAR2 (both within 0.2).
+    # REP_FAR2 is the far bigger cluster, but distance is primary -> REP_BASE wins.
+    clusters, cloneTable = build_frames(
+        buckets=[("REP_BASE", BASE, 2), ("REP_FAR2", FAR2, 10)],
+        singletons=[("SNG", A1)],
+    )
+    out = reassign_singletons(clusters, cloneTable, MIN_SEQ_ID)
+    assert cluster_of(out, "SNG") == "REP_BASE"
+
+
+def test_larger_cluster_breaks_distance_tie():
+    # SNG=BASE is exactly 1 edit from both reps (equal distance) -> tie broken by size.
+    clusters, cloneTable = build_frames(
+        buckets=[("REP_SMALL", A1, 2), ("REP_BIG", A2, 5)],
+        singletons=[("SNG", BASE)],
+    )
+    out = reassign_singletons(clusters, cloneTable, MIN_SEQ_ID)
+    assert cluster_of(out, "SNG") == "REP_BIG"
+
+
+def test_mixed_batch_of_singletons():
+    clusters, cloneTable = build_frames(
+        buckets=[("REP_BASE", BASE, 3)],
+        singletons=[("NEAR", A1), ("FARAWAY", FAR)],
+    )
+    out = reassign_singletons(clusters, cloneTable, MIN_SEQ_ID)
+    assert cluster_of(out, "NEAR") == "REP_BASE"
+    assert cluster_of(out, "FARAWAY") == "FARAWAY"
+
+
+def test_no_singletons_is_noop():
+    clusters, cloneTable = build_frames(
+        buckets=[("REP_BASE", BASE, 2), ("REP_A2", A2, 3)],
+        singletons=[],
+    )
+    out = reassign_singletons(clusters, cloneTable, MIN_SEQ_ID)
+    assert out.sort("clonotypeKey").equals(clusters.sort("clonotypeKey"))
+
+
+def test_no_non_singleton_clusters_is_noop():
+    clusters, cloneTable = build_frames(
+        buckets=[],
+        singletons=[("S1", BASE), ("S2", A1)],
+    )
+    out = reassign_singletons(clusters, cloneTable, MIN_SEQ_ID)
+    assert out.sort("clonotypeKey").equals(clusters.sort("clonotypeKey"))
+
+
+def test_no_sequence_column_is_noop():
+    clusters = pl.DataFrame({"clusterId": ["c1", "c1", "s1"],
+                             "clonotypeKey": ["c1", "c1_m", "s1"]})
+    cloneTable = pl.DataFrame({"clonotypeKey": ["c1", "c1_m", "s1"]})  # no seq column
+    out = reassign_singletons(clusters, cloneTable, MIN_SEQ_ID)
+    assert out.sort("clonotypeKey").equals(clusters.sort("clonotypeKey"))
+
+
+@pytest.mark.slow
+def test_scaled_runs_without_materializing_all_pairs():
+    """Many singletons x many centroids: must complete with bounded memory and
+    return a well-formed frame."""
+    rng = random.Random(0)
+    aa = "ACDEFGHIKLMNPQRSTVWY"
+
+    def rseq(n):
+        return "".join(rng.choice(aa) for _ in range(n))
+
+    buckets = [(f"B{j}", rseq(12), 2) for j in range(2000)]
+    singletons = [(f"S{i}", rseq(9)) for i in range(2000)]
+    clusters, cloneTable = build_frames(buckets, singletons)
+    out = reassign_singletons(clusters, cloneTable, MIN_SEQ_ID)
+    # every original row is preserved (only clusterId may change)
+    assert out.height == clusters.height
+    assert set(out.columns) == {"clusterId", "clonotypeKey"}
+
+
+@pytest.mark.parametrize("flush_rows", [1, 7, 25, 101, 10**9])
+def test_pending_overflow_reduction_is_correct(flush_rows):
+    """Force the flush_rows reduction branch on tiny input and confirm the result is
+    unchanged across thresholds.
+
+    Construction: 10 singletons and 10 buckets, where SNG_i is 1 edit from REP_i and
+    2 edits from every other REP_j (all within 0.2), so each singleton matches ALL 10
+    buckets -> ~100 candidate rows, and the unique closest for SNG_i is REP_i.
+    With flush_rows=1 the running best is reduced after every matching bucket (many
+    flushes); with flush_rows=1e9 it is reduced once at the end. Both -- and every value
+    between -- must yield the same, correct SNG_i -> REP_i mapping.
+    """
+    n = 10  # positions 0..9 within the length-12 BASE
+
+    def sub(seq, pos, ch):
+        return seq[:pos] + ch + seq[pos + 1:]
+
+    # 'W'/'H' don't occur in BASE[0:10], so every edit is a real 1-char change and
+    # singleton vs centroid edits never coincide.
+    buckets = [(f"REP{j}", sub(BASE, j, "H"), 2) for j in range(n)]
+    singletons = [(f"SNG{i}", sub(BASE, i, "W")) for i in range(n)]
+    clusters, cloneTable = build_frames(buckets, singletons)
+
+    out = reassign_singletons(clusters, cloneTable, MIN_SEQ_ID, flush_rows=flush_rows)
+    for i in range(n):
+        assert cluster_of(out, f"SNG{i}") == f"REP{i}"

--- a/software/uv.lock
+++ b/software/uv.lock
@@ -1,0 +1,125 @@
+version = 1
+revision = 3
+requires-python = "==3.12.*"
+
+[[package]]
+name = "clonotype-clustering-calc-script"
+version = "0.0.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "polars-ds-lts-cpu" },
+    { name = "polars-lts-cpu" },
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "polars-ds-lts-cpu", specifier = "==0.10.2" },
+    { name = "polars-lts-cpu", specifier = "==1.33.1" },
+    { name = "pytest", specifier = ">=8.0.0" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polars-ds-lts-cpu"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-lts-cpu" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/58/b3507c5661753c9b9adb2660f09fb166b9bca973d3438a4061004adf10bb/polars_ds_lts_cpu-0.10.2.tar.gz", hash = "sha256:bf644b1906c1680fb7d4af8f156e26c54e00efadf36356e7d7e8f8121ea65436", size = 2073603, upload-time = "2025-10-31T16:54:13.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/68/978cec60fed93291a55937ba4be040cb6826dc498b55ab42d139713f2625/polars_ds_lts_cpu-0.10.2-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:85c39a29d28958d7e0ebef4a7ebb2b73b6c5d170e4b12d82cbcf01aa269f9170", size = 14000199, upload-time = "2025-10-31T16:54:00.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fc/eafbd5a99f6645231dfede19b43265e9abee52f040297d01480c13e21a8b/polars_ds_lts_cpu-0.10.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:dc3782badec90af32ff08ce970386d7a8cda49016a2cb8c90d315b5ee9e724aa", size = 12313490, upload-time = "2025-10-31T16:54:03.21Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/4a/fbb254dbc2b737295972d4b1963821d223ec1cc08a425286cd3288cded4d/polars_ds_lts_cpu-0.10.2-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f49d5a059e35afb1082a1f14c00105596e65946d9215c060fada2a3efaa84ca2", size = 14564116, upload-time = "2025-10-31T16:54:05.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0f/50306e852aa221f5afe4118d66485eed806f2e657338b49879d1ba3cca0b/polars_ds_lts_cpu-0.10.2-cp310-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:910c178fe94aea9ca1e86f90276571005c6decbd1cc83fe3006813ce9e81ae1d", size = 12629354, upload-time = "2025-10-31T16:54:08.003Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a8/a806f38c7f24209b4dab8dfaf83644b372e3afef03ec7388ca8fdba401b6/polars_ds_lts_cpu-0.10.2-cp310-abi3-win_amd64.whl", hash = "sha256:bb6de38f4e5e313d1ba8467d95f4ddd6019a15d94dbfbf45f27803b3f604903f", size = 15418738, upload-time = "2025-10-31T16:54:10.747Z" },
+]
+
+[[package]]
+name = "polars-lts-cpu"
+version = "1.33.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/93/a0c4200a5e0af2eee31ea79330cb1f5f4c58f604cb3de352f654e2010c81/polars_lts_cpu-1.33.1.tar.gz", hash = "sha256:0a5426d95ec9eec937a56d3e7cf7911a4b5486c42f4dbbcc9512aa706039322c", size = 4822741, upload-time = "2025-09-09T08:37:51.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/9b/75916636b33724afabe820b0993f60dc243793421d6f680d5fcb531fe170/polars_lts_cpu-1.33.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:5db75d1b424bd8aa34c9a670a901592f1931cc94d9fb32bdd428dbaad8c33761", size = 38908638, upload-time = "2025-09-09T08:37:02.258Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e2/dc77b81650ba0c631c06f05d8e81faacee87730600fceca372273facf77b/polars_lts_cpu-1.33.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:37cf3a56cf447c69cfb3f9cd0e714d5b0c754705d7b497b9ab86cbf56e36b3e7", size = 35638895, upload-time = "2025-09-09T08:37:07.575Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fb/4dcff801d71dfa02ec682d6b32fd0ce5339de48797f663698d5f8348ffe7/polars_lts_cpu-1.33.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:656b530a672fe8fbd4c212b2a8481099e5cef63e84970975619ea7c25faeb833", size = 39585825, upload-time = "2025-09-09T08:37:11.631Z" },
+    { url = "https://files.pythonhosted.org/packages/54/31/0474c14dce2c0507bea40069daafb848980ba7c351ad991908e51ac895fb/polars_lts_cpu-1.33.1-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:64574c784380b37167b3db3a7cfdb9839cd308e89b8818859d2ffb34a9c896b2", size = 36685020, upload-time = "2025-09-09T08:37:15.597Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0a/5ebba9b145388ffbbd09fa84ac3cd7d336b922e34256b1417abf0a1c2fb9/polars_lts_cpu-1.33.1-cp39-abi3-win_amd64.whl", hash = "sha256:6b849e0e1485acb8ac39bf13356d280ea7c924c2b41cd548ea6e4d102d70be77", size = 39191650, upload-time = "2025-09-09T08:37:19.541Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ad/bf3db68d30ac798ca31c80624709a0c03aa890e2e20e5ca987d7e55fcfc2/polars_lts_cpu-1.33.1-cp39-abi3-win_arm64.whl", hash = "sha256:c99ab56b059cee6bcabe9fb89e97f5813be1012a2251bf77f76e15c2d1cba934", size = 35445244, upload-time = "2025-09-09T08:37:22.97Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,21 @@
     "build": {
       "dependsOn": ["^build", "check"],
       "inputs": ["$TURBO_DEFAULT$"],
-      "env": ["PL_PKG_DEV", "PL_DOCKER_REGISTRY_PUSH_TO"],
+      "env": [
+        "PL_DOCKER_REGISTRY_PUSH_TO",
+        "PL_BUILD_CHANNEL",
+        "PL_BUILD_VARIANT",
+        "PL_BUILD_LOCATION",
+        "PL_BUILD_USE_PUBLISHED",
+        "PL_DEV_DOCKER_PUSH_URL",
+        "PL_DEV_DOCKER_PULL_URL",
+        "PL_DEV_BINARY_UPLOAD_URL",
+        "PL_RELEASE_DOCKER_PUSH_URL",
+        "PL_RELEASE_DOCKER_PULL_URL",
+        "PL_RELEASE_BINARY_UPLOAD_URL",
+        "PL_REGISTRY_PLATFORMA_OPEN_UPLOAD_URL"
+      ],
+      "passThroughEnv": ["AWS_*", "PL_AWS_*"],
       "outputs": ["./dist/**", "./block-pack/**", "./pkg-*.tgz"]
     },
     "build:dev": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,6 @@
     "watch": "ts-builder build --target block-ui --watch",
     "build": "ts-builder build --target block-ui",
     "type-check": "ts-builder type-check --target block-ui",
-    "test": "vitest",
     "do-pack": "shx rm -f *.tgz && pnpm pack && shx mv *.tgz package.tgz",
     "fmt": "ts-builder format",
     "check": "ts-builder check --target block-ui"


### PR DESCRIPTION
…lustering

High-precision reassignment cross-joined every singleton with every non-singleton centroid, materializing n_singletons x n_centroids rows. On large repertoires this overflows polars' 2^32 row limit and the process-results step dies with "ComputeError: cross joins would produce more rows than fits into 2^32".

Replace the all-pairs cross join with, per centroid: a length-band prefilter (a match needs |len_s - len_c| <= (1-min_seq_id)*max_len), a bounded filter_by_levenshtein prefilter, and the exact normalized recheck. Keep only a running best-per-singleton with periodic reduction, so peak memory is O(#singletons) and no cross join is built. Reassignment result (closest centroid, then largest cluster) is unchanged.

Extract reassign_singletons into its own importable module and add a pytest suite (pyproject + uv.lock + Python Tests workflow, mirroring sibling blocks) with regression/golden cases and a parametrized flush-threshold test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash (`ComputeError: cross joins would produce more rows than fits into 2^32`) in high-precision singleton reassignment on large repertoires by replacing the all-pairs cross-join with a per-centroid length-band prefilter → bounded `filter_by_levenshtein` prefilter → exact recheck pipeline, keeping only a running best-per-singleton in memory. It also extracts the reassignment logic into a standalone `reassign_singletons.py` module with a comprehensive pytest suite.

- **OOM fix**: The new `reassign_singletons` function iterates over centroids one at a time, giving O(#singletons) peak memory instead of O(#singletons × #centroids).
- **Testing**: New `test_reassign_singletons.py` covers reassignment correctness plus a scale test that exercises the full prefilter pipeline and flush/reduction path.
- **CI/infra**: New `python-tests.yaml` workflow, updated `build.yaml`, and dependency bumps across the `pnpm` lockfile.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The core algorithm change is correct and well-tested; the OOM crash path is eliminated without changing reassignment semantics.

The three-stage per-centroid prefilter cleanly replaces the cross-join without altering the reassignment result. Both findings are non-blocking style and efficiency concerns safe to fix as follow-ups.

The max_len_all / filter_by_levenshtein bound logic in software/src/reassign_singletons.py (lines 100-133) deserves a second look for datasets with wide sequence-length distributions.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| software/src/reassign_singletons.py | New standalone module implementing the OOM-safe singleton reassignment algorithm. Core three-stage filter pipeline is logically correct; two P2 findings noted. |
| software/src/process_results.py | Imports and delegates to the new `reassign_singletons` module; no substantive logic changes. |
| software/tests/test_reassign_singletons.py | Comprehensive test suite covering reassignment correctness, scale, and parametrized flush-threshold tests. |
| .github/workflows/python-tests.yaml | New workflow running pytest via uv on PRs/pushes to main. |
| .github/workflows/build.yaml | Switches runner, adds HZ CI secrets, enables tests, separates dev/release build scripts. |
| software/pyproject.toml | Adds pytest and polars dev dependencies; configures pytest paths, markers, ruff linting. |

</details>

<sub>Reviews (2): Last reviewed commit: ["MILAB-6582: align @milaboratories/helper..."](https://github.com/platforma-open/clonotype-clustering/commit/949f8b09af3189512d15675e4292244f1fa22b14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42994178)</sub>

**Context used:**

- Context used - Terms is a types in codebase. Provide the list of ... ([source](https://app.greptile.com/review/custom-context?memory=instruction-0))

<!-- /greptile_comment -->