### PR TITLE
fix: separate pframe column id key and counter to prevent id collisions

### DIFF
--- a/.changeset/pframe-column-id-separator.md
+++ b/.changeset/pframe-column-id-separator.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.clonotype-clustering.workflow": patch
+---
+
+Fix an intermittent `field "….spec" is already set` block failure. Export pFrame column ids are now built from sorted keys with a `_` separator before the running index, so distinct columns can no longer collide (previously e.g. `sequence_1`+`18` and `sequence_11`+`8` both produced `sequence_118`) and ids no longer depend on Tengo map iteration order.

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -1042,7 +1042,7 @@ wf.body(func(args) {
 	i := 0
 	for pf in [trimmedSeqPf, cloneToClusterLinkPf, distancesPf] {
 		for k, v in pf {
-			msaPf.add(k + string(i), trace.inject(v.spec), v.data)
+			msaPf.add(k + "_" + string(i), trace.inject(v.spec), v.data)
 			i = i + 1
 		}
 	}
@@ -1052,7 +1052,7 @@ wf.body(func(args) {
 	i = 0
 	for pf in [abundancesPf, cloneToClusterPf, cloneToClusterLinkPf, clusterToSeqPf, abundancesPerClusterPf, distancesPf, clusterRadiusPf] {
 		for k, v in pf {
-			epf.add(k + string(i), trace.inject(v.spec), v.data) // label, specs, data
+			epf.add(k + "_" + string(i), trace.inject(v.spec), v.data) // label, specs, data
 			i = i + 1
 		}
 	}

--- a/workflow/src/main.tpl.tengo
+++ b/workflow/src/main.tpl.tengo
@@ -1041,7 +1041,8 @@ wf.body(func(args) {
 	msaPf := pframes.pFrameBuilder()
 	i := 0
 	for pf in [trimmedSeqPf, cloneToClusterLinkPf, distancesPf] {
-		for k, v in pf {
+		for k in maps.getKeys(pf) {
+			v := pf[k]
 			msaPf.add(k + "_" + string(i), trace.inject(v.spec), v.data)
 			i = i + 1
 		}
@@ -1051,7 +1052,8 @@ wf.body(func(args) {
 	epf := pframes.pFrameBuilder() 
 	i = 0
 	for pf in [abundancesPf, cloneToClusterPf, cloneToClusterLinkPf, clusterToSeqPf, abundancesPerClusterPf, distancesPf, clusterRadiusPf] {
-		for k, v in pf {
+		for k in maps.getKeys(pf) {
+			v := pf[k]
 			epf.add(k + "_" + string(i), trace.inject(v.spec), v.data) // label, specs, data
 			i = i + 1
 		}


### PR DESCRIPTION
## Before
Export column ids concatenated the map key and a monotonic counter with **no separator** (`k + string(i)`), so two distinct `(key, counter)` pairs could collapse to the same id — e.g. `sequence_1` + `18` and `sequence_11` + `8` both rendered to `sequence_118`. The SDK pframe builder correctly rejects the duplicate id, which surfaced in production as:

    tengo template error: assertion error: condition failed: field "sequence_….spec" is already set

It fired intermittently: the collision needs key names that end in digits **and** the counter to reach ≥ 10 for the boundary to become ambiguous, so whether it triggered depended on dataset shape / column count.

## After
A `"_"` separator makes each id unambiguous — `sequence_1_18` vs `sequence_11_8`. `string(i)` is pure digits, so the **last** underscore always splits the id back into a unique `(key, counter)` pair; no two pairs can collide.

## How
`k + string(i)` → `k + "_" + string(i)` at both pframe-builder sites in `workflow/src/main.tpl.tengo` (2 hunks, nothing else changed). Sibling fixed-prefix sites (single `"…" + string(i)` calls) are intentionally left as-is — the added underscore also isolates the `k + "_" + …` ids from those fixed-prefix ids.

## Caveat — internal column ids change
This changes internal pframe column ids (`sequence_118` → `sequence_1_18`). Verified while making the change that column **selection** is spec-based (`SUniversalPColumnId`), not the builder id, and that these dynamically-generated ids can't be referenced literally by any static consumer or test. The one thing to confirm at merge: that no persisted per-project view state (table column order/visibility, plot axis defaults) keys off the literal builder id — if it did, existing saved projects would reset that view state to defaults on next run (cosmetic; no data loss, no block failure).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a production bug where pframe column ids could collide when map keys ended in digits and the monotonic counter reached ≥ 10, causing the SDK builder to reject duplicate ids. The fix adds a `"_"` separator between the dynamic key and the counter at two pframe-builder sites.

- **`msaPf` builder** (line 1045): `k + string(i)` → `k + "_" + string(i)`, making ids like `sequence_1_18` unambiguous from `sequence_11_8`.
- **`epf` builder** (line 1055): Same change, covering the larger export pframe that aggregates seven data sources plus an optional `centroidLinkPf`.
- **No other pframe sites affected**: The `centroidLink` fixed-prefix pattern and the `cdb` builder both use alphabetic-only prefixes (no digit-suffix risk) and are correctly left unchanged.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is two characters wide, targets exactly the broken concatenation sites, and does not touch any other logic.

The bug is clearly described and the fix is provably correct: since the counter i is globally unique within each builder, appending _ + string(i) (which is always purely numeric) after an underscore makes every id unambiguous. All other builder patterns in the file were examined — the centroidLink fixed-prefix and cdb fixed-prefix loops have no digit-suffix ambiguity and are correctly left untouched. The only known side-effect (internal column id strings changing for existing saved projects) is cosmetic, acknowledged in the PR, and carries no data loss risk.

No files require special attention. The single changed file has a well-understood, minimal diff.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workflow/src/main.tpl.tengo | Two-character fix ('_' separator) at both dynamic-key pframe builder sites; all other builder patterns (fixed-prefix, direct-key) are correctly left unchanged. Change is minimal and complete. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["for pf in [pf1, pf2, ...]"] --> B["for k, v in pf"]
    B --> C{"Before fix"}
    C -->|"k + string(i)"| D["Possible collision: 'sequence_1' + '18' == 'sequence_11' + '8' == 'sequence_118'"]
    C -->|"k + '_' + string(i)"| E["Unambiguous id: 'sequence_1_18' vs 'sequence_11_8'"]
    B --> F["i = i + 1"]
    F --> B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["for pf in [pf1, pf2, ...]"] --> B["for k, v in pf"]
    B --> C{"Before fix"}
    C -->|"k + string(i)"| D["Possible collision: 'sequence_1' + '18' == 'sequence_11' + '8' == 'sequence_118'"]
    C -->|"k + '_' + string(i)"| E["Unambiguous id: 'sequence_1_18' vs 'sequence_11_8'"]
    B --> F["i = i + 1"]
    F --> B
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: separate pframe column id key and c..."](https://github.com/platforma-open/clonotype-clustering/commit/18b9ee02efe2e853894664ccec9c0fcf94619963) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44121750)</sub>

<!-- /greptile_comment -->